### PR TITLE
Command Suggestion for Incorrect Subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 _output/
+/shp
+/shp-*
+/bin/*

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/shipwright-io/build v0.3.1-0.20210330182238-23d2672f2f61
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/cli-runtime v0.19.7

--- a/go.sum
+++ b/go.sum
@@ -731,6 +731,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tektoncd/pipeline v0.21.0/go.mod h1:GwdfGGt/5VhZL8JvJu8kFz8friKufcJ/TJkJmK6uc0U=
 github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
+github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c h1:HelZ2kAFadG0La9d+4htN4HzQ68Bm2iM9qKMSMES6xg=
+github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c/go.mod h1:JlzghshsemAMDGZLytTFY8C1JQxQPhnatWqNwUXjggo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/shp/cmd/root_test.go
+++ b/pkg/shp/cmd/root_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/onsi/gomega"
+	"github.com/shipwright-io/cli/test/stub"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -15,5 +17,13 @@ func TestCMD_NewCmdSHP(t *testing.T) {
 	genericOpts := &genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	cmd := NewCmdSHP(genericOpts)
 
-	g.Expect(cmd).NotTo(gomega.BeNil())
+	out, err := stub.ExecuteCommand(cmd, "build", "cr")
+
+	if err == nil {
+		t.Errorf("No errors was defined. Output: %s", out)
+	}
+
+	expected := fmt.Sprintf("unknown command %q for %q\n\nDid you mean this?\n\t%s\n", "cr", "shp build", "create")
+
+	g.Expect(err.Error()).To(gomega.Equal(expected))
 }

--- a/pkg/shp/suggestion/suggest.go
+++ b/pkg/shp/suggestion/suggest.go
@@ -1,0 +1,90 @@
+package suggestion
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/texttheater/golang-levenshtein/levenshtein"
+)
+
+// SubcommandsRequiredWithSuggestions will ensure we have a subcommand provided by the user and augments it with
+// suggestion for commands, alias and help on root command.
+func SubcommandsRequiredWithSuggestions(cmd *cobra.Command, args []string) error {
+	requireMsg := "unknown command %q for %q"
+	typedName := ""
+	// This will be triggered if cobra didn't find any subcommands.
+	// Find some suggestions.
+	var suggestions []string
+
+	if len(args) != 0 && !cmd.DisableSuggestions {
+		typedName += args[0]
+		if cmd.SuggestionsMinimumDistance <= 0 {
+			cmd.SuggestionsMinimumDistance = 2
+		}
+		// subcommand suggestions
+		suggestions = cmd.SuggestionsFor(args[0])
+
+		// subcommand alias suggestions (with distance, not exact)
+		for _, c := range cmd.Commands() {
+			if !c.IsAvailableCommand() {
+				continue
+			}
+
+			candidate := suggestsByPrefixOrLd(typedName, c.Name(), cmd.SuggestionsMinimumDistance)
+			if candidate == "" {
+				continue
+			}
+			_, found := Find(suggestions, candidate)
+			if !found {
+				suggestions = append(suggestions, candidate)
+			}
+		}
+
+		// help for root command
+		if !cmd.HasParent() {
+			candidate := suggestsByPrefixOrLd(typedName, "help", cmd.SuggestionsMinimumDistance)
+			if candidate != "" {
+				suggestions = append(suggestions, candidate)
+			}
+		}
+	}
+
+	var suggestionsMsg string
+	if len(suggestions) > 0 {
+		suggestionsMsg += "\nDid you mean this?\n"
+		for _, s := range suggestions {
+			suggestionsMsg += fmt.Sprintf("\t%v\n", s)
+		}
+	}
+
+	if suggestionsMsg != "" {
+		requireMsg = fmt.Sprintf("%s\n%s", requireMsg, suggestionsMsg)
+		return fmt.Errorf(requireMsg, typedName, cmd.CommandPath())
+	}
+
+	return cmd.Help()
+}
+
+// suggestsByPrefixOrLd suggests a command by levenshtein distance or by prefix.
+// It returns an empty string if nothing was found
+func suggestsByPrefixOrLd(typedName, candidate string, minDistance int) string {
+	levenshteinVariable := levenshtein.DistanceForStrings([]rune(typedName), []rune(candidate), levenshtein.DefaultOptions)
+	suggestByLevenshtein := levenshteinVariable <= minDistance
+	suggestByPrefix := strings.HasPrefix(strings.ToLower(candidate), strings.ToLower(typedName))
+	if !suggestByLevenshtein && !suggestByPrefix {
+		return ""
+	}
+	return candidate
+}
+
+// Find takes a slice and looks for an element in it. If found it will
+// return it's key, otherwise it will return -1 and a bool of false.
+func Find(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/pkg/shp/suggestion/suggest_test.go
+++ b/pkg/shp/suggestion/suggest_test.go
@@ -1,0 +1,25 @@
+package suggestion
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/shipwright-io/cli/pkg/shp/cmd/build"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestSuggestion(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	genericOpts := &genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	cmd := build.Command(nil, genericOpts)
+
+	err := SubcommandsRequiredWithSuggestions(cmd, []string{"cr"})
+
+	expected := fmt.Sprintf("unknown command %q for %q\n\nDid you mean this?\n\t%s\n", "cr", "build", "create")
+
+	g.Expect(err.Error()).To(gomega.Equal(expected))
+}

--- a/test/stub/cobra.go
+++ b/test/stub/cobra.go
@@ -1,0 +1,27 @@
+package stub
+
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+)
+
+// ExecuteCommand executes the root command passing the args and returns
+// the output as a string and error
+func ExecuteCommand(root *cobra.Command, args ...string) (string, error) {
+	_, output, err := ExecuteCommandC(root, args...)
+	return output, err
+}
+
+// ExecuteCommandC executes the root command passing the args and returns
+// the root command, output as a string and error if any
+func ExecuteCommandC(c *cobra.Command, args ...string) (*cobra.Command, string, error) {
+	buf := new(bytes.Buffer)
+	c.SetOutput(buf)
+	c.SetArgs(args)
+	c.SilenceUsage = true
+
+	root, err := c.ExecuteC()
+
+	return root, buf.String(), err
+}

--- a/vendor/github.com/texttheater/golang-levenshtein/levenshtein/LICENSE
+++ b/vendor/github.com/texttheater/golang-levenshtein/levenshtein/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Kilian Evang and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/texttheater/golang-levenshtein/levenshtein/go.mod
+++ b/vendor/github.com/texttheater/golang-levenshtein/levenshtein/go.mod
@@ -1,0 +1,3 @@
+module github.com/texttheater/golang-levenshtein/levenshtein
+
+go 1.13

--- a/vendor/github.com/texttheater/golang-levenshtein/levenshtein/levenshtein.go
+++ b/vendor/github.com/texttheater/golang-levenshtein/levenshtein/levenshtein.go
@@ -1,0 +1,262 @@
+// This package implements the Levenshtein algorithm for computing the
+// similarity between two strings. The central function is MatrixForStrings,
+// which computes the Levenshtein matrix. The functions DistanceForMatrix,
+// EditScriptForMatrix and RatioForMatrix read various interesting properties
+// off the matrix. The package also provides the convenience functions
+// DistanceForStrings, EditScriptForStrings and RatioForStrings for going
+// directly from two strings to the property of interest.
+package levenshtein
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type EditOperation int
+
+const (
+	Ins = iota
+	Del
+	Sub
+	Match
+)
+
+type EditScript []EditOperation
+
+type MatchFunction func(rune, rune) bool
+
+// IdenticalRunes is the default MatchFunction: it checks whether two runes are
+// identical.
+func IdenticalRunes(a rune, b rune) bool {
+	return a == b
+}
+
+type Options struct {
+	InsCost int
+	DelCost int
+	SubCost int
+	Matches MatchFunction
+}
+
+// DefaultOptions is the default options without substitution: insertion cost
+// is 1, deletion cost is 1, substitution cost is 2 (meaning insert and delete
+// will be used instead), and two runes match iff they are identical.
+var DefaultOptions Options = Options{
+	InsCost: 1,
+	DelCost: 1,
+	SubCost: 2,
+	Matches: IdenticalRunes,
+}
+
+// DefaultOptionsWithSub is the default options with substitution: insertion
+// cost is 1, deletion cost is 1, substitution cost is 1, and two runes match
+// iff they are identical.
+var DefaultOptionsWithSub Options = Options{
+	InsCost: 1,
+	DelCost: 1,
+	SubCost: 1,
+	Matches: IdenticalRunes,
+}
+
+func (operation EditOperation) String() string {
+	if operation == Match {
+		return "match"
+	} else if operation == Ins {
+		return "ins"
+	} else if operation == Sub {
+		return "sub"
+	}
+	return "del"
+}
+
+// DistanceForStrings returns the edit distance between source and target.
+//
+// It has a runtime proportional to len(source) * len(target) and memory use
+// proportional to len(target).
+func DistanceForStrings(source []rune, target []rune, op Options) int {
+	// Note: This algorithm is a specialization of MatrixForStrings.
+	// MatrixForStrings returns the full edit matrix. However, we only need a
+	// single value (see DistanceForMatrix) and the main loop of the algorithm
+	// only uses the current and previous row. As such we create a 2D matrix,
+	// but with height 2 (enough to store current and previous row).
+	height := len(source) + 1
+	width := len(target) + 1
+	matrix := make([][]int, 2)
+
+	// Initialize trivial distances (from/to empty string). That is, fill
+	// the left column and the top row with row/column indices multiplied
+	// by deletion/insertion cost.
+	for i := 0; i < 2; i++ {
+		matrix[i] = make([]int, width)
+		matrix[i][0] = i * op.DelCost
+	}
+	for j := 1; j < width; j++ {
+		matrix[0][j] = j * op.InsCost
+	}
+
+	// Fill in the remaining cells: for each prefix pair, choose the
+	// (edit history, operation) pair with the lowest cost.
+	for i := 1; i < height; i++ {
+		cur := matrix[i%2]
+		prev := matrix[(i-1)%2]
+		cur[0] = i * op.DelCost
+		for j := 1; j < width; j++ {
+			delCost := prev[j] + op.DelCost
+			matchSubCost := prev[j-1]
+			if !op.Matches(source[i-1], target[j-1]) {
+				matchSubCost += op.SubCost
+			}
+			insCost := cur[j-1] + op.InsCost
+			cur[j] = min(delCost, min(matchSubCost, insCost))
+		}
+	}
+	return matrix[(height-1)%2][width-1]
+}
+
+// DistanceForMatrix reads the edit distance off the given Levenshtein matrix.
+func DistanceForMatrix(matrix [][]int) int {
+	return matrix[len(matrix)-1][len(matrix[0])-1]
+}
+
+// RatioForStrings returns the Levenshtein ratio for the given strings. The
+// ratio is computed as follows:
+//
+//     (sourceLength + targetLength - distance) / (sourceLength + targetLength)
+func RatioForStrings(source []rune, target []rune, op Options) float64 {
+	matrix := MatrixForStrings(source, target, op)
+	return RatioForMatrix(matrix)
+}
+
+// RatioForMatrix returns the Levenshtein ratio for the given matrix. The ratio
+// is computed as follows:
+//
+//     (sourceLength + targetLength - distance) / (sourceLength + targetLength)
+func RatioForMatrix(matrix [][]int) float64 {
+	sourcelength := len(matrix) - 1
+	targetlength := len(matrix[0]) - 1
+	sum := sourcelength + targetlength
+
+	if sum == 0 {
+		return 0
+	}
+
+	dist := DistanceForMatrix(matrix)
+	return float64(sum-dist) / float64(sum)
+}
+
+// MatrixForStrings generates a 2-D array representing the dynamic programming
+// table used by the Levenshtein algorithm, as described e.g. here:
+// http://www.let.rug.nl/kleiweg/lev/
+// The reason for putting the creation of the table into a separate function is
+// that it cannot only be used for reading of the edit distance between two
+// strings, but also e.g. to backtrace an edit script that provides an
+// alignment between the characters of both strings.
+func MatrixForStrings(source []rune, target []rune, op Options) [][]int {
+	// Make a 2-D matrix. Rows correspond to prefixes of source, columns to
+	// prefixes of target. Cells will contain edit distances.
+	// Cf. http://www.let.rug.nl/~kleiweg/lev/levenshtein.html
+	height := len(source) + 1
+	width := len(target) + 1
+	matrix := make([][]int, height)
+
+	// Initialize trivial distances (from/to empty string). That is, fill
+	// the left column and the top row with row/column indices multiplied
+	// by deletion/insertion cost.
+	for i := 0; i < height; i++ {
+		matrix[i] = make([]int, width)
+		matrix[i][0] = i * op.DelCost
+	}
+	for j := 1; j < width; j++ {
+		matrix[0][j] = j * op.InsCost
+	}
+
+	// Fill in the remaining cells: for each prefix pair, choose the
+	// (edit history, operation) pair with the lowest cost.
+	for i := 1; i < height; i++ {
+		for j := 1; j < width; j++ {
+			delCost := matrix[i-1][j] + op.DelCost
+			matchSubCost := matrix[i-1][j-1]
+			if !op.Matches(source[i-1], target[j-1]) {
+				matchSubCost += op.SubCost
+			}
+			insCost := matrix[i][j-1] + op.InsCost
+			matrix[i][j] = min(delCost, min(matchSubCost,
+				insCost))
+		}
+	}
+	//LogMatrix(source, target, matrix)
+	return matrix
+}
+
+// EditScriptForStrings returns an optimal edit script to turn source into
+// target.
+func EditScriptForStrings(source []rune, target []rune, op Options) EditScript {
+	return backtrace(len(source), len(target),
+		MatrixForStrings(source, target, op), op)
+}
+
+// EditScriptForMatrix returns an optimal edit script based on the given
+// Levenshtein matrix.
+func EditScriptForMatrix(matrix [][]int, op Options) EditScript {
+	return backtrace(len(matrix)-1, len(matrix[0])-1, matrix, op)
+}
+
+// WriteMatrix writes a visual representation of the given matrix for the given
+// strings to the given writer.
+func WriteMatrix(source []rune, target []rune, matrix [][]int, writer io.Writer) {
+	fmt.Fprintf(writer, "    ")
+	for _, targetRune := range target {
+		fmt.Fprintf(writer, "  %c", targetRune)
+	}
+	fmt.Fprintf(writer, "\n")
+	fmt.Fprintf(writer, "  %2d", matrix[0][0])
+	for j, _ := range target {
+		fmt.Fprintf(writer, " %2d", matrix[0][j+1])
+	}
+	fmt.Fprintf(writer, "\n")
+	for i, sourceRune := range source {
+		fmt.Fprintf(writer, "%c %2d", sourceRune, matrix[i+1][0])
+		for j, _ := range target {
+			fmt.Fprintf(writer, " %2d", matrix[i+1][j+1])
+		}
+		fmt.Fprintf(writer, "\n")
+	}
+}
+
+// LogMatrix writes a visual representation of the given matrix for the given
+// strings to os.Stderr. This function is deprecated, use
+// WriteMatrix(source, target, matrix, os.Stderr) instead.
+func LogMatrix(source []rune, target []rune, matrix [][]int) {
+	WriteMatrix(source, target, matrix, os.Stderr)
+}
+
+func backtrace(i int, j int, matrix [][]int, op Options) EditScript {
+	if i > 0 && matrix[i-1][j]+op.DelCost == matrix[i][j] {
+		return append(backtrace(i-1, j, matrix, op), Del)
+	}
+	if j > 0 && matrix[i][j-1]+op.InsCost == matrix[i][j] {
+		return append(backtrace(i, j-1, matrix, op), Ins)
+	}
+	if i > 0 && j > 0 && matrix[i-1][j-1]+op.SubCost == matrix[i][j] {
+		return append(backtrace(i-1, j-1, matrix, op), Sub)
+	}
+	if i > 0 && j > 0 && matrix[i-1][j-1] == matrix[i][j] {
+		return append(backtrace(i-1, j-1, matrix, op), Match)
+	}
+	return []EditOperation{}
+}
+
+func min(a int, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+func max(a int, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,6 +87,9 @@ github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 ## explicit
 github.com/spf13/pflag
+# github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c
+## explicit
+github.com/texttheater/golang-levenshtein/levenshtein
 # golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20210119194325-5f4716e94777


### PR DESCRIPTION
Earlier there were no suggestions for shp subcommands but with this patch entering wrong subcommands will give suggestions.
example:- 
```
$ shp build cr

Error: unknown command "cr" for "shp build"

Did you mean this?
	create
```

Also updated the `.gitignore` file to ignore the binary generated after running `go build ./cmd/shp` and also ignoring `.vscode` dir

Signed-off-by: vinamra28 <vinjain@redhat.com>