### PR TITLE
add pr template in preparation for enabling release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+# Changes
+
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+<!-- If this PR fixes a GitHub issue, please mention it like so:
+
+Fixes #<insert issue number here>
+
+-->
+
+# Submitter Checklist
+
+- [ ] Includes tests if functionality changed/was added
+- [ ] Includes docs if changes are user-facing
+- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
+- [ ] Release notes block has been filled in, or marked NONE
+
+See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
+for details on coding conventions, github and prow interactions, and the code review process.
+
+# Release Notes
+
+<!--
+Describe any user facing changes here, or delete this block.
+
+Examples of user facing changes:
+- API changes
+- Bug fixes
+- Any changes in behavior
+- Changes requiring upgrade notices or deprecation warnings
+
+For pull requests with a release note:
+
+```release-note
+Your release note here
+```
+
+For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
+
+```release-note
+action required: your release note here
+```
+
+For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
+
+```release-note
+NONE
+```
+-->


### PR DESCRIPTION
/assign @adambkaplan 
/assign @imjasonh 

for now this points to the contributing guide in the build repo, as I saw no contributing guide here

my preference would be that if we need a separate guide, it be done in a separate pr