### PR TITLE
Add cross-compile build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG = ./pkg/...
 BIN ?= $(OUTPUT_DIR)/$(APP)
 KUBECTL_BIN ?= $(OUTPUT_DIR)/kubectl-$(APP)
 
-GO_FLAGS ?= -v -mod=vendor
+GO_FLAGS ?= -mod=vendor
 GO_TEST_FLAGS ?= -race -cover
 
 ARGS ?=
@@ -17,6 +17,9 @@ $(BIN):
 	go build $(GO_FLAGS) -o $(BIN) $(CMD)
 
 build: $(BIN)
+
+build-cross:
+	hack/build-cross.sh "$(GO_FLAGS)" $(OUTPUT_DIR)
 
 install: build
 	install -m 0755 $(BIN) /usr/local/bin/

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+GOFLAGS=$1
+outputDir=$2
+
+rm -rf "${outputDir}"
+mkdir -p "${outputDir}"
+
+linuxArches=( "amd64" "arm64" )
+darwinArches=( "amd64" )
+windowsArches=( "amd64" )
+
+for arch in "${linuxArches[@]}"; do
+    echo "Compiling shp for linux/${arch}"
+    env GOOS=linux GOARCH="${arch}" go build ${GOFLAGS} -o "${outputDir}/shp-linux-${arch}" ./cmd/shp/...
+done
+
+for arch in "${darwinArches[@]}"; do
+    echo "Compiling shp for darwin/${arch}"
+    env GOOS=darwin GOARCH="${arch}" go build ${GOFLAGS} -o "${outputDir}/shp-darwin-${arch}" ./cmd/shp/...
+done
+
+for arch in "${windowsArches[@]}"; do
+    echo "Compiling shp for windows/${arch}"
+    env GOOS=windows GOARCH="${arch}" go build ${GOFLAGS} -o "${outputDir}/shp-windows-${arch}.exe" ./cmd/shp/...
+done


### PR DESCRIPTION
Created script and makefile target to cross-compile the shp binary for
Linux, macOS, and Windows. Currently supports amd64 across all operating
systems, and arm64 on Linux.