### PR TITLE
Go-Report-Card Fixes

### DIFF
--- a/pkg/shp/cmd/build/doc.go
+++ b/pkg/shp/cmd/build/doc.go
@@ -1,2 +1,2 @@
-// build contains types and functions for build cobra sub-command
+// Package build contains types and functions for build cobra sub-command
 package build

--- a/pkg/shp/cmd/buildrun/buildrun.go
+++ b/pkg/shp/cmd/buildrun/buildrun.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shipwright-io/cli/pkg/shp/params"
 )
 
+// Command represents "shp buildrun" sub-command.
 func Command(p *params.Params, ioStreams *genericclioptions.IOStreams) *cobra.Command {
 	command := &cobra.Command{
 		Use:     "buildrun",

--- a/pkg/shp/cmd/buildrun/doc.go
+++ b/pkg/shp/cmd/buildrun/doc.go
@@ -1,2 +1,2 @@
-// buildrun contains types and functions for buildrun cobra sub-command
+// Package buildrun contains types and functions for buildrun cobra sub-command
 package buildrun

--- a/pkg/shp/flags/doc.go
+++ b/pkg/shp/flags/doc.go
@@ -3,7 +3,7 @@
 //
 // For instance:
 //
-// 	 cmd := &cobra.Command{}
+//   cmd := &cobra.Command{}
 //   br := flags.BuildRunSpecFromFlags(cmd.Flags())
 //   flags.SanitizeBuildRunSpec(&br.Spec)
 //

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -10,22 +10,38 @@ import (
 )
 
 const (
-	BuildrefNameFlag             = "buildref-name"
-	BuilderImageFlag             = "builder-image"
+	// BuildrefNameFlag command-line flag.
+	BuildrefNameFlag = "buildref-name"
+	// BuilderImageFlag command-line flag.
+	BuilderImageFlag = "builder-image"
+	// BuilderCredentialsSecretFlag command-line flag.
 	BuilderCredentialsSecretFlag = "builder-credentials-secret"
-	DockerfileFlag               = "dockerfile"
-	SourceURLFlag                = "source-url"
-	SourceRevisionFlag           = "source-revision"
-	SourceContextDirFlag         = "source-context-dir"
-	SourceCredentialsSecretFlag  = "source-credentials-secret"
-	StrategyAPIVersionFlag       = "strategy-apiversion"
-	StrategyKindFlag             = "strategy-kind"
-	StrategyNameFlag             = "strategy-name"
-	OutputImageFlag              = "output-image"
-	OutputCredentialsSecretFlag  = "output-credentials-secret"
-	ServiceAccountNameFlag       = "sa-name"
-	ServiceAccountGenerateFlag   = "sa-generate"
-	TimeoutFlag                  = "timeout"
+	// DockerfileFlag command-line flag.
+	DockerfileFlag = "dockerfile"
+	// SourceURLFlag command-line flag.
+	SourceURLFlag = "source-url"
+	// SourceRevisionFlag command-line flag.
+	SourceRevisionFlag = "source-revision"
+	// SourceContextDirFlag command-line flag.
+	SourceContextDirFlag = "source-context-dir"
+	// SourceCredentialsSecretFlag command-line flag.
+	SourceCredentialsSecretFlag = "source-credentials-secret"
+	// StrategyAPIVersionFlag command-line flag.
+	StrategyAPIVersionFlag = "strategy-apiversion"
+	// StrategyKindFlag command-line flag.
+	StrategyKindFlag = "strategy-kind"
+	// StrategyNameFlag command-line flag.
+	StrategyNameFlag = "strategy-name"
+	// OutputImageFlag command-line flag.
+	OutputImageFlag = "output-image"
+	// OutputCredentialsSecretFlag command-line flag.
+	OutputCredentialsSecretFlag = "output-credentials-secret"
+	// ServiceAccountNameFlag command-line flag.
+	ServiceAccountNameFlag = "sa-name"
+	// ServiceAccountGenerateFlag command-line flag.
+	ServiceAccountGenerateFlag = "sa-generate"
+	// TimeoutFlag command-line flag.
+	TimeoutFlag = "timeout"
 )
 
 // sourceFlags flags for ".spec.source"

--- a/pkg/shp/params/params.go
+++ b/pkg/shp/params/params.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// ShipwrightParams is a place for Shipwright CLI to store its runtime parameters
-// including configured dynamic client and global flags
+// Params is a place for Shipwright CLI to store its runtime parameters including configured dynamic
+// client and global flags.
 type Params struct {
 	client    dynamic.Interface
 	clientset kubernetes.Interface
@@ -50,6 +50,7 @@ func (p *Params) Client() (dynamic.Interface, error) {
 	return p.client, nil
 }
 
+// ClientSet returns a kubernetes clientset.
 func (p *Params) ClientSet() (kubernetes.Interface, error) {
 	if p.clientset != nil {
 		return p.clientset, nil

--- a/pkg/shp/resource/doc.go
+++ b/pkg/shp/resource/doc.go
@@ -1,5 +1,4 @@
-// resource contains Resource type and functions for interacting with it
-// it is a wrapper around kubernetes dynamic client that has
-// most of the necessary type info incapsulated
-// which allows us to work easier with objects stored in kubernetes
+// Package resource contains Resource type and functions for interacting with it's a wrapper around
+// kubernetes dynamic client that has most of the necessary type info encapsulated which allows us to
+// manipulate Kubernetes objects.
 package resource

--- a/pkg/shp/resource/resource.go
+++ b/pkg/shp/resource/resource.go
@@ -48,6 +48,7 @@ func (r *Resource) Create(ctx context.Context, name string, obj interface{}) err
 	return util.CreateObject(ctx, ri, name, r.gv.WithKind(r.kind), obj)
 }
 
+// Update execute update against informed object.
 func (r *Resource) Update(ctx context.Context, name string, obj interface{}) error {
 	ri, err := r.getResourceInterface()
 	if err != nil {
@@ -91,6 +92,7 @@ func (r *Resource) Get(ctx context.Context, name string, result interface{}) err
 	return util.GetObject(ctx, ri, name, result)
 }
 
+// Watch returns a watch for informed list options.
 func (r *Resource) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	ri, err := r.getResourceInterface()
 	if err != nil {

--- a/pkg/shp/util/crud.go
+++ b/pkg/shp/util/crud.go
@@ -40,6 +40,7 @@ func CreateObject(ctx context.Context, resource dynamic.ResourceInterface, name 
 	return fromUnstructured(result.Object, obj)
 }
 
+// UpdateObject updates informed object reference.
 func UpdateObject(ctx context.Context, resource dynamic.ResourceInterface, name string, gvk schema.GroupVersionKind, obj interface{}) error {
 	u, err := toUnstructured(name, gvk, obj)
 	if err != nil {

--- a/pkg/shp/util/doc.go
+++ b/pkg/shp/util/doc.go
@@ -1,2 +1,2 @@
-// util contains utility function and constants used in other packages.
+// Package util contains utility function and constants used in other packages.
 package util


### PR DESCRIPTION
# Changes

General fixes for go-report-card, typos and minor refactoring. Fixing the following alerts:

```
$ goreportcard-cli -v
2021/07/03 09:25:37 disabling misspell on large repo...
Grade: A+ (99.9%)
Files: 2043
Issues: 10
gofmt: 100%
go_vet: 100%
gocyclo: 99%
	pkg/shp/reactor/pod_watcher.go
		Line 59: warning: cyclomatic complexity 18 of function (*PodWatcher).Start() is high (> 15) (gocyclo)
golint: 99%
	pkg/shp/params/params.go
		Line 11: warning: comment on exported type Params should be of the form "Params ..." (with optional leading article) (golint)
		Line 53: warning: exported method Params.ClientSet should have comment or be unexported (golint)
	pkg/shp/flags/flags.go
		Line 13: warning: exported const BuildrefNameFlag should have comment (or a comment on this block) or be unexported (golint)
	pkg/shp/resource/doc.go
		Line 1: warning: package comment should be of the form "Package resource ..." (golint)
	pkg/shp/cmd/build/doc.go
		Line 1: warning: package comment should be of the form "Package build ..." (golint)
	pkg/shp/util/crud.go
		Line 43: warning: exported function UpdateObject should have comment or be unexported (golint)
	pkg/shp/util/doc.go
		Line 1: warning: package comment should be of the form "Package util ..." (golint)
	pkg/shp/resource/resource.go
		Line 51: warning: exported method Resource.Update should have comment or be unexported (golint)
		Line 94: warning: exported method Resource.Watch should have comment or be unexported (golint)
	pkg/shp/cmd/buildrun/buildrun.go
		Line 12: warning: exported function Command should have comment or be unexported (golint)
	pkg/shp/cmd/buildrun/doc.go
		Line 1: warning: package comment should be of the form "Package buildrun ..." (golint)
license: 100%
ineffassign: 100%
misspell: 100%
```

# Submitter Checklist

- [x] ~Includes tests if functionality changed/was added~
- [x] ~Includes docs if changes are user-facing~
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```