### PR TITLE
Add generic Kubectl binary download script for all Linux distributions

### DIFF
--- a/hack/install-kubectl.sh
+++ b/hack/install-kubectl.sh
@@ -5,33 +5,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #
-# Installs "kubectl" on Travis-CI Ubuntu.
+# Installs "kubectl"
 #
 
-set -eu
+set -euo pipefail
 
-sudo apt-get update > /dev/null && \
-    sudo apt-get install -y \
-        apt-transport-https \
-        curl \
-        git
+# Find a suitable install location
+for CANDIDATE in "$HOME/bin" "/usr/local/bin" "/usr/bin"; do
+  if [[ -w $CANDIDATE ]] && grep -q "$CANDIDATE" <<<"$PATH"; then
+    TARGET_DIR="$CANDIDATE"
+    break
+  fi
+done
 
-#
-# Kubectl
-#
-
-echo "# Configuring kubectl APT repository..."
-
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    |sudo apt-key add -
-
-if [ ! -f "/etc/apt/sources.list.d/kubernetes.list" ] ; then
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" \
-        |sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+# Bail out in case no suitable location could be found
+if [[ -z ${TARGET_DIR:-} ]]; then
+  echo -e "Unable to determine a writable install location. Make sure that you have write access to either \\033[1m/usr/local/bin\\033[0m or \\033[1m${HOME}/bin\\033[0m and that is in your PATH."
+  exit 1
 fi
 
-echo "# Installing kubectl..."
-sudo apt-get update && \
-    sudo apt-get install -y kubectl
+# Look-up current stable version from their release site
+STABLE_VERSION="$(curl --fail --silent --location https://dl.k8s.io/release/stable.txt)"
 
-echo "# Kubectl version: `kubectl version`"
+echo "# Downloading kubectl binary..."
+curl --fail --progress-bar --location "https://dl.k8s.io/release/${STABLE_VERSION}/bin/linux/amd64/kubectl" --output "${TARGET_DIR}/kubectl" && \
+  chmod a+rx "${TARGET_DIR}/kubectl"
+
+echo "# Validating kubectl binary..."
+sha256sum --check <<<"$(curl --fail --silent --location "https://dl.k8s.io/${STABLE_VERSION}/bin/linux/amd64/kubectl.sha256") ${TARGET_DIR}/kubectl"
+
+echo "# Kubectl version"
+kubectl version --client


### PR DESCRIPTION
# Changes

Kubectl binary download script modification has been done to accommodate support for all Linux distributions. It is relatively short, requires no sudo and should run on most distros just fine.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ ] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```