### PR TITLE
Start buildrun follow logs test

### DIFF
--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -1,0 +1,165 @@
+package build
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	shpfake "github.com/shipwright-io/build/pkg/client/clientset/versioned/fake"
+	"github.com/shipwright-io/cli/pkg/shp/flags"
+	"github.com/shipwright-io/cli/pkg/shp/params"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/fake"
+	fakekubetesting "k8s.io/client-go/testing"
+)
+
+func TestStartBuildRunFollowLog(t *testing.T) {
+	tests := []struct {
+		name       string
+		phase      corev1.PodPhase
+		logText    string
+		cancelled  bool
+		brDeleted  bool
+		podDeleted bool
+	}{
+		{
+			name:    "succeeded",
+			phase:   corev1.PodSucceeded,
+			logText: "Pod 'testpod' has succeeded!",
+		},
+		{
+			name:    "pending",
+			phase:   corev1.PodPending,
+			logText: "Pod 'testpod' is in state \"Pending\"",
+		},
+		{
+			name:    "unknown",
+			phase:   corev1.PodUnknown,
+			logText: "Pod 'testpod' is in state \"Unknown\"",
+		},
+		{
+			name:      "failed-cancelled",
+			phase:     corev1.PodFailed,
+			cancelled: true,
+			logText:   "BuildRun 'testpod' has been canceled.",
+		},
+		{
+			name:      "failed-br-deleted",
+			phase:     corev1.PodFailed,
+			brDeleted: true,
+			logText:   "BuildRun 'testpod' has been deleted.",
+		},
+		{
+			name:       "failed-pod-deleted",
+			phase:      corev1.PodFailed,
+			podDeleted: true,
+			logText:    "Pod 'testpod' has been deleted.",
+		},
+		{
+			name:    "failed-something-else",
+			phase:   corev1.PodFailed,
+			logText: "Pod 'testpod' has failed!",
+		},
+		{
+			name:  "running",
+			phase: corev1.PodRunning,
+			// we do not verify log text here; the k8s fake client stuff around watches, getting pods logs, and
+			// what we do in this repo's tail logic is unreliable, and we've received guidance from some upstream
+			// k8s folks to "be careful" with it; fortunately, what we do for tail and pod_watcher so far is within
+			// the realm of reliable.
+		},
+	}
+
+	for _, test := range tests {
+		name := "testpod"
+		containerName := "container"
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: metav1.NamespaceDefault,
+				Name:      name,
+				Labels: map[string]string{
+					buildv1alpha1.LabelBuild:    name,
+					buildv1alpha1.LabelBuildRun: name,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: containerName,
+				}},
+			},
+		}
+		br := &buildv1alpha1.BuildRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: metav1.NamespaceDefault,
+				Name:      name,
+			},
+		}
+		shpclientset := shpfake.NewSimpleClientset()
+		// need this reactor since the Run method uses the ObjectMeta.GenerateName k8s feature to generate the random
+		// name for the BuildRun.  However, for our purposes with unit testing, we want to control the name of the BuildRun
+		// to facilitate the list/selector via labels that is also employed by the Run method.
+		createReactorFunc := func(action fakekubetesting.Action) (handled bool, ret kruntime.Object, err error) {
+			return true, br, nil
+		}
+		shpclientset.PrependReactor("create", "buildruns", createReactorFunc)
+		// need this reactor to handle returning our test BuildRun with whatever updates we make based on the various
+		// test bools that result in spec.state or deletion timestamp updates
+		getReactorFunc := func(action fakekubetesting.Action) (handled bool, ret kruntime.Object, err error) {
+			return true, br, nil
+		}
+		shpclientset.PrependReactor("get", "buildruns", getReactorFunc)
+		kclientset := fake.NewSimpleClientset(pod)
+		ccmd := &cobra.Command{}
+		cmd := &RunCommand{
+			cmd:             ccmd,
+			buildRunName:    name,
+			buildRunSpec:    flags.BuildRunSpecFromFlags(ccmd.Flags()),
+			follow:          true,
+			shpClientset:    shpclientset,
+			tailLogsStarted: make(map[string]bool),
+			watchLock:       sync.Mutex{},
+		}
+
+		// set up context
+		cmd.Cmd().ExecuteC()
+		param := params.NewParamsForTest(kclientset, shpclientset, nil, metav1.NamespaceDefault)
+
+		ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+
+		switch {
+		case test.cancelled:
+			br.Spec.State = buildv1alpha1.BuildRunStateCancel
+		case test.brDeleted:
+			br.DeletionTimestamp = &metav1.Time{}
+		case test.podDeleted:
+			pod.DeletionTimestamp = &metav1.Time{}
+		}
+
+		cmd.Complete(param, []string{name})
+		go func() {
+			err := cmd.Run(param, &ioStreams)
+			if err != nil {
+				t.Errorf("%s", err.Error())
+			}
+
+		}()
+
+		// yield the processor, so the initialization in Run can occur; afterward, the watchLock should allow
+		// coordination between Run and onEvent
+		runtime.Gosched()
+
+		// mimic watch events, bypassing k8s fake client watch hoopla whose plug points are not always useful;
+		pod.Status.Phase = test.phase
+		cmd.onEvent(pod)
+		if !strings.Contains(out.String(), test.logText) {
+			t.Errorf("test %s: unexpected output: %s", test.name, out.String())
+		}
+
+	}
+}


### PR DESCRIPTION
# Changes

add unit test for previously provided live log follow / tail of invoking build run from referenced build via cli

unit tests uncovered some race conditions previously unseen with manual testing

/kind cleanup

/assign @otaviof 
/assign @coreydaley 
/assign @HeavyWombat 

after a bunch of back and forth with myself today (preceded by a conversation with @otaviof ) 
I gave up trying to get k8s fake clients to work with watches, etc. and am just testing the function in this package

we have tests in pod_watcher and tail for those functions

 in looking at the panic we saw in @HeavyWombat 's https://github.com/shipwright-io/cli/pull/35 I do believe line 64 in run.go is in the Run() method, so in theory this test calling that method would have caught that error.

But as @otaviof mentioned to me today, and I agree, e2e tests that run against an api server are also needed for this component long term

# Submitter Checklist

- [ /] Includes tests if functionality changed/was added
- [ n/a] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [/ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

