### PR TITLE
Pass name to shp for create build and create buildrun

### DIFF
--- a/pkg/shp/cmd/build/create.go
+++ b/pkg/shp/cmd/build/create.go
@@ -53,7 +53,12 @@ func (c *CreateCommand) Validate() error {
 
 // Run executes the creation of a new Build instance using flags to fill up the details.
 func (c *CreateCommand) Run(params *params.Params, io *genericclioptions.IOStreams) error {
-	b := &buildv1alpha1.Build{Spec: *c.buildSpec}
+	b := &buildv1alpha1.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.name,
+		},
+		Spec: *c.buildSpec,
+	}
 	flags.SanitizeBuildSpec(&b.Spec)
 
 	clientset, err := params.ShipwrightClientSet()

--- a/pkg/shp/cmd/buildrun/create.go
+++ b/pkg/shp/cmd/buildrun/create.go
@@ -54,7 +54,12 @@ func (c *CreateCommand) Validate() error {
 
 // Run executes the creation of BuildRun object.
 func (c *CreateCommand) Run(params *params.Params, ioStreams *genericclioptions.IOStreams) error {
-	br := &buildv1alpha1.BuildRun{Spec: *c.buildRunSpec}
+	br := &buildv1alpha1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.name,
+		},
+		Spec: *c.buildRunSpec,
+	}
 	flags.SanitizeBuildRunSpec(&br.Spec)
 
 	clientset, err := params.ShipwrightClientSet()

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -6,3 +6,21 @@ source test/e2e/helpers.sh
 	result="$(shp --help)"
 	[ ! -z "$result" ]
 }
+
+@test "shp build create succesfully run with 1 argument" {
+	build_name=$(random_name)
+	result="$(shp build create ${build_name} --source-url=url --output-image=image)"
+        [ ! -z "$result" ]
+	result=$(kubectl get build.shipwright.io ${build_name})
+	[ ! -z "$result" ]
+}
+
+@test "shp buildrun create succesfully run with 1 argument" {
+        build_name=$(random_name)
+        result="$(shp build create ${build_name} --source-url=url --output-image=image)"
+        [ ! -z "$result" ]
+	buildrun_name=$(random_name)
+        result="$(shp buildrun create ${buildrun_name} --buildref-name={$build_name})"
+	result=$(kubectl get buildrun.shipwright.io ${buildrun_name})
+        [ ! -z "$result" ]
+}	

--- a/test/e2e/helpers.sh
+++ b/test/e2e/helpers.sh
@@ -16,3 +16,8 @@ function shp () {
 
 	${BIN} ${*}
 }
+
+function random_name () {
+	tr -dc a-z </dev/urandom | head -c64
+}
+


### PR DESCRIPTION
# Changes

Fixes #42 
`shp build create` and `shp buildrun create` now correctly handle their respective type creation by accepting and passing the build/buildrun to the shipwrigt client.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
`shp build create` and `shp buildrun create` now correctly handle their respective type creation by accepting and passing the build/buildrun to the shipwrigt client.
```
