### PR TITLE
more RunCommand initialization verification for TestStartBuildRunFollowLogs

### DIFF
--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -162,7 +162,9 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 		// the init to occur.
 		cmd.watchLock.Lock()
 		err := wait.PollImmediate(1*time.Second, 3*time.Second, func() (done bool, err error) {
-			if cmd.pw != nil {
+			// check any of the vars on RunCommand that are used in onEvent and make sure they are set;
+			// we are verifying the initialization done in Run() on RunCommand is complete
+			if cmd.pw != nil && cmd.ioStreams != nil && cmd.shpClientset != nil {
 				cmd.watchLock.Unlock()
 				return true, nil
 			}


### PR DESCRIPTION
# Changes

Fixes #48 

/kind bug

/assign @coreydaley 
/assign @jkhelil

# Submitter Checklist

- [ /] Includes tests if functionality changed/was added
- [ n/a] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ /] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

