### PR TITLE
Do not set timeout to 0s

### DIFF
--- a/pkg/shp/flags/build.go
+++ b/pkg/shp/flags/build.go
@@ -57,4 +57,7 @@ func SanitizeBuildSpec(b *buildv1alpha1.BuildSpec) {
 			b.Builder = nil
 		}
 	}
+	if b.Timeout != nil && b.Timeout.Duration == 0 {
+		b.Timeout = nil
+	}
 }

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -155,6 +155,12 @@ func TestSanitizeBuildSpec(t *testing.T) {
 		name: "should not clean-up complete objects",
 		in:   completeBuildSpec,
 		out:  completeBuildSpec,
+	}, {
+		name: "should clean-up 0s duration",
+		in: buildv1alpha1.BuildSpec{Timeout: &metav1.Duration{
+			Duration: time.Duration(0),
+		}},
+		out: buildv1alpha1.BuildSpec{Timeout: nil},
 	}}
 
 	for _, tt := range testCases {

--- a/pkg/shp/flags/buildrun.go
+++ b/pkg/shp/flags/buildrun.go
@@ -49,4 +49,7 @@ func SanitizeBuildRunSpec(br *buildv1alpha1.BuildRunSpec) {
 			br.Output = nil
 		}
 	}
+	if br.Timeout != nil && br.Timeout.Duration == 0 {
+		br.Timeout = nil
+	}
 }

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -107,6 +107,12 @@ func TestSanitizeBuildRunSpec(t *testing.T) {
 		name: "should not clean-up complete objects",
 		in:   completeBuildRunSpec,
 		out:  completeBuildRunSpec,
+	}, {
+		name: "should clean-up 0s duration",
+		in: buildv1alpha1.BuildRunSpec{Timeout: &metav1.Duration{
+			Duration: time.Duration(0),
+		}},
+		out: buildv1alpha1.BuildRunSpec{Timeout: nil},
 	}}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
Fixes #54

When passing no timeout, `time.Duration(0)` was taken. This caused `0s` as value in the Build and BuildRun spec. We are passing that on to Tekton and then it crashes because it sets the Pod's `spec.activeDeadlineSeconds` to `0` which is not allowed.

My change replaces a 0s timeout with `nil`. This effectively means that providing no timeout through the CLI leads to no timeout in the objects.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Set no timeout in Build or BuildRun when no value for the `--timeout` argument is set
```
