### PR TITLE
various run build -F/--follow fixes around timeout, lack of pods, and data races

### DIFF
--- a/pkg/shp/cmd/build/create.go
+++ b/pkg/shp/cmd/build/create.go
@@ -35,7 +35,7 @@ func (c *CreateCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills internal subcommand structure for future work with user input
-func (c *CreateCommand) Complete(params *params.Params, args []string) error {
+func (c *CreateCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	switch len(args) {
 	case 1:
 		c.name = args[0]

--- a/pkg/shp/cmd/build/delete.go
+++ b/pkg/shp/cmd/build/delete.go
@@ -41,7 +41,7 @@ func (c *DeleteCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills DeleteSubCommand structure with data obtained from cobra command
-func (c *DeleteCommand) Complete(params *params.Params, args []string) error {
+func (c *DeleteCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	c.name = args[0]
 
 	return nil

--- a/pkg/shp/cmd/build/list.go
+++ b/pkg/shp/cmd/build/list.go
@@ -39,7 +39,7 @@ func (c *ListCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills object with user input data
-func (c *ListCommand) Complete(params *params.Params, args []string) error {
+func (c *ListCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	return nil
 }
 

--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -189,8 +189,8 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 			return false, nil
 		})
 		if err != nil {
-			cmd.watchLock.Unlock()
 			t.Errorf("test %s: Run initialization did not complete in time: pw %#v ioStreams %#v shpClientset %#v", test.name, cmd.pw, cmd.ioStreams, cmd.shpClientset)
+			cmd.watchLock.Unlock()
 		}
 
 		// mimic watch events, bypassing k8s fake client watch hoopla whose plug points are not always useful;

--- a/pkg/shp/cmd/buildrun/cancel.go
+++ b/pkg/shp/cmd/buildrun/cancel.go
@@ -38,7 +38,7 @@ func (c *CancelCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills in data provided by user
-func (c *CancelCommand) Complete(params *params.Params, args []string) error {
+func (c *CancelCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	c.name = args[0]
 
 	return nil

--- a/pkg/shp/cmd/buildrun/create.go
+++ b/pkg/shp/cmd/buildrun/create.go
@@ -36,7 +36,7 @@ func (c *CreateCommand) Cmd() *cobra.Command {
 }
 
 // Complete checks if the arguments is informing the BuildRun name.
-func (c *CreateCommand) Complete(params *params.Params, args []string) error {
+func (c *CreateCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	switch len(args) {
 	case 1:
 		c.name = args[0]

--- a/pkg/shp/cmd/buildrun/delete.go
+++ b/pkg/shp/cmd/buildrun/delete.go
@@ -35,7 +35,7 @@ func (c *DeleteCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills in data provided by user
-func (c *DeleteCommand) Complete(params *params.Params, args []string) error {
+func (c *DeleteCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	c.name = args[0]
 
 	return nil

--- a/pkg/shp/cmd/buildrun/list.go
+++ b/pkg/shp/cmd/buildrun/list.go
@@ -42,7 +42,7 @@ func (c *ListCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills in data provided by user
-func (c *ListCommand) Complete(params *params.Params, args []string) error {
+func (c *ListCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	return nil
 }
 

--- a/pkg/shp/cmd/buildrun/logs.go
+++ b/pkg/shp/cmd/buildrun/logs.go
@@ -39,7 +39,7 @@ func (c *LogsCommand) Cmd() *cobra.Command {
 }
 
 // Complete fills in data provided by user
-func (c *LogsCommand) Complete(params *params.Params, args []string) error {
+func (c *LogsCommand) Complete(params *params.Params, io *genericclioptions.IOStreams, args []string) error {
 	c.name = args[0]
 
 	return nil

--- a/pkg/shp/cmd/runner/interface.go
+++ b/pkg/shp/cmd/runner/interface.go
@@ -13,7 +13,7 @@ type SubCommand interface {
 	// Cmd shares the cobra.Command instance.
 	Cmd() *cobra.Command
 	// Complete aggregate data needed for the sub-command primary logic.
-	Complete(params *params.Params, args []string) error
+	Complete(params *params.Params, ioStreams *genericclioptions.IOStreams, args []string) error
 	// Validate perform validation against the context collected.
 	Validate() error
 	// Run execute the primary sub-command logic.

--- a/pkg/shp/cmd/runner/runner.go
+++ b/pkg/shp/cmd/runner/runner.go
@@ -26,7 +26,7 @@ func (r *Runner) Cmd() *cobra.Command {
 // RunE cobra.Command's RunE implementation focusing on sub-commands lifecycle. To achieve it, a
 // dynamic client and configured namespace are informed.
 func (r *Runner) RunE(cmd *cobra.Command, args []string) error {
-	if err := r.subCmd.Complete(r.p, args); err != nil {
+	if err := r.subCmd.Complete(r.p, r.ioStreams, args); err != nil {
 		return err
 	}
 	if err := r.subCmd.Validate(); err != nil {

--- a/pkg/shp/cmd/runner/runner_test.go
+++ b/pkg/shp/cmd/runner/runner_test.go
@@ -20,7 +20,7 @@ func (m *mockedSubCommand) Cmd() *cobra.Command {
 	return testCmd
 }
 
-func (m *mockedSubCommand) Complete(p *params.Params, args []string) error {
+func (m *mockedSubCommand) Complete(p *params.Params, ioStreams *genericclioptions.IOStreams, args []string) error {
 	return nil
 }
 

--- a/pkg/shp/params/params.go
+++ b/pkg/shp/params/params.go
@@ -1,6 +1,10 @@
 package params
 
 import (
+	"math"
+	"strings"
+	"time"
+
 	buildclientset "github.com/shipwright-io/build/pkg/client/clientset/versioned"
 	"github.com/spf13/pflag"
 
@@ -45,6 +49,19 @@ func (p *Params) ClientSet() (kubernetes.Interface, error) {
 	}
 
 	return p.clientset, nil
+}
+
+// RequestTimeout returns the setting from k8s --request-timeout param
+func (p *Params) RequestTimeout() (time.Duration, error) {
+	if p.configFlags.Timeout == nil {
+		return math.MaxInt64, nil
+	}
+	// 0 or empty also mean no timeout
+	to := strings.TrimSpace(*p.configFlags.Timeout)
+	if len(to) == 0 || to == "0" || strings.HasPrefix(to, "0") {
+		return math.MaxInt64, nil
+	}
+	return time.ParseDuration(*p.configFlags.Timeout)
 }
 
 // ShipwrightClientSet returns a Shipwright Clientset

--- a/pkg/shp/reactor/pod_watcher.go
+++ b/pkg/shp/reactor/pod_watcher.go
@@ -90,8 +90,8 @@ func (p *PodWatcher) WithNoPodEventsYetFn(fn NoPodEventsYetFn) *PodWatcher {
 
 // handleEvent applies user informed functions against informed pod and event.
 func (p *PodWatcher) handleEvent(pod *corev1.Pod, event watch.Event) error {
-	p.stopLock.Lock()
-	defer p.stopLock.Unlock()
+	//p.stopLock.Lock()
+	//defer p.stopLock.Unlock()
 	p.eventTicker.Stop()
 	switch event.Type {
 	case watch.Added:
@@ -185,9 +185,9 @@ func (p *PodWatcher) Stop() {
 	// along with canceling of builds
 	p.stopLock.Lock()
 	defer p.stopLock.Unlock()
+	p.eventTicker.Stop()
 	if !p.stopped {
 		close(p.stopCh)
-		p.eventTicker.Stop()
 		p.stopped = true
 	}
 }

--- a/test/e2e/run-follow.bats
+++ b/test/e2e/run-follow.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+source test/e2e/helpers.sh
+
+setup() {
+	load 'bats/support/load'
+	load 'bats/assert/load'
+	load 'bats/file/load'
+}
+
+teardown() {
+	run kubectl delete builds.shipwright.io --all
+	run kubectl delete buildruns.shipwright.io --all
+}
+
+@test "shp build run follow verification" {
+  	# generate random names for our build and buildrun
+  	build_name=$(random_name)
+  	buildrun_name=$(random_name)
+
+    # create a Build with two environment variables
+    run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image
+    assert_success
+
+    # initiate a BuildRun with -F
+    run shp build run ${build_name} -F
+    #assert_success
+    #TODO
+    # currently do not check success because the create build sample I pulled from either of the existing e2e's do
+    # not run to success, both locally and CI; for the one pulled from envvars:
+    #     [build-and-push] ERROR: No buildpack groups passed detection.
+    #     [build-and-push] ERROR: Please check that you are running against the correct path.
+    #     [build-and-push] ERROR: failed to detect: no buildpacks participating
+    # ideally, we pull additional items from shipwright-io/build and sort that out, as it uses https://github.com/shipwright-io/sample-go.
+    # All that said, the key element for this e2e, log following, is still verifiable
+
+
+    # confirm output that would only exist if following BuildRun logs
+    assert_output --partial "[source-default]"
+    assert_output --partial "[place-tools]"
+    assert_output --partial "[build-and-push]"
+
+    # initiate a BuildRun with --follow
+    run shp build run ${build_name} --follow
+    #TODO see above
+    #assert_success
+
+     # confirm output that would only exist if following BuildRun logs
+     assert_output --partial "[source-default]"
+     assert_output --partial "[place-tools]"
+     assert_output --partial "[build-and-push]"
+}


### PR DESCRIPTION
# Changes

Fixes #53
- adds/tweaks integration from k8s `--request-timeout` and `--context` options that `shp` inherits from k8s to apply request or context deadline timeout / aborts on `ship build run --follow`
- add callbacks for lack of pod events, including cross reference with build run when those occur, just as we do when pod events do occur (still no explicit buildrun watch to go with pod watch, as multiple watches proves untenable with unit testing, plus over-indulgent, as we only need buildrun for terminal states), to exit --follow
- slight refactor of SubCommand interface to allow for more initialization in Complete() vs. Run() for --follow
- which allowed vast simplification of data race prevention on RunCommand
- and removal of what proved to be kludgy thread coordination in --follow unit tests

# Submitter Checklist

- [ /] Includes tests if functionality changed/was added
- [n/a ] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [/ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

/kind bug

# Release Notes


```release-note
fully integrate options '--context' and '--request-timeout' into 'shp build run --follow' 
allow for exit if the underlying Pod for a BuildRun is never created
concurrency fixes
```

@adambkaplan 
@coreydaley 
@SaschaSchwarze0 
@otaviof 


