### PR TITLE
Make sure Dockerfile is not set to empty string

### DIFF
--- a/pkg/shp/flags/build.go
+++ b/pkg/shp/flags/build.go
@@ -65,4 +65,7 @@ func SanitizeBuildSpec(b *buildv1alpha1.BuildSpec) {
 	if b.Timeout != nil && b.Timeout.Duration == 0 {
 		b.Timeout = nil
 	}
+	if b.Dockerfile != nil && *b.Dockerfile == "" {
+		b.Dockerfile = nil
+	}
 }

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -127,6 +127,8 @@ func TestSanitizeBuildSpec(t *testing.T) {
 		},
 	}
 
+	emptyString := ""
+
 	testCases := []struct {
 		name string
 		in   buildv1alpha1.BuildSpec
@@ -161,6 +163,10 @@ func TestSanitizeBuildSpec(t *testing.T) {
 			Duration: time.Duration(0),
 		}},
 		out: buildv1alpha1.BuildSpec{Timeout: nil},
+	}, {
+		name: "should clean-up an empty Dockerfile",
+		in:   buildv1alpha1.BuildSpec{Dockerfile: &emptyString},
+		out:  buildv1alpha1.BuildSpec{Dockerfile: nil},
 	}}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
# Changes

When creating a build like this:

```sh
$ shp build create sample-go --source-url https://github.com/shipwright-io/sample-go --source-context-dir docker-build --strategy-name kaniko --output-image ... --output-credentials-secret ...
```

then, `spec.dockerfile` was set to `""` which does not work. It is defined as a `*string` and therefore must be set to `nil` instead.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
When providing no value for the --dockerfile argument during build creation, then it is not anymore set to an empty string
```
