### PR TITLE
Remove duplicate buildrun logs command

### DIFF
--- a/pkg/shp/cmd/buildrun/buildrun.go
+++ b/pkg/shp/cmd/buildrun/buildrun.go
@@ -24,7 +24,6 @@ func Command(p *params.Params, ioStreams *genericclioptions.IOStreams) *cobra.Co
 	command.AddCommand(
 		runner.NewRunner(p, ioStreams, listCmd()).Cmd(),
 		runner.NewRunner(p, ioStreams, logsCmd()).Cmd(),
-		runner.NewRunner(p, ioStreams, logsCmd()).Cmd(),
 		runner.NewRunner(p, ioStreams, createCmd()).Cmd(),
 		runner.NewRunner(p, ioStreams, cancelCmd()).Cmd(),
 	)


### PR DESCRIPTION
# Changes

When running `shp buildrun help`, then the `logs` subcommand was listed twice:

```sh
$ shp buildrun help
Manage BuildRuns

Usage:
  shp buildrun [flags]
  shp buildrun [command]

Aliases:
  buildrun, br

Available Commands:
  cancel      Cancel BuildRun
  create      Creates a BuildRun instance.
  list        List Builds
  logs        See BuildRun log output
  logs        See BuildRun log output

[...]
```

Fixing this.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
`shp buildrun help` now only lists the logs sub-command once rather than twice
```