### PR TITLE
Ensure revision is not set to an empty string

### DIFF
--- a/pkg/shp/flags/build.go
+++ b/pkg/shp/flags/build.go
@@ -51,6 +51,9 @@ func SanitizeBuildSpec(b *buildv1alpha1.BuildSpec) {
 	if b.Source.Credentials != nil && b.Source.Credentials.Name == "" {
 		b.Source.Credentials = nil
 	}
+	if b.Source.Revision != nil && *b.Source.Revision == "" {
+		b.Source.Revision = nil
+	}
 	if b.Builder != nil {
 		if b.Builder.Credentials != nil && b.Builder.Credentials.Name == "" {
 			b.Builder.Credentials = nil

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -167,6 +167,14 @@ func TestSanitizeBuildSpec(t *testing.T) {
 		name: "should clean-up an empty Dockerfile",
 		in:   buildv1alpha1.BuildSpec{Dockerfile: &emptyString},
 		out:  buildv1alpha1.BuildSpec{Dockerfile: nil},
+	}, {
+		name: "should clean-up an empty revision",
+		in: buildv1alpha1.BuildSpec{Source: buildv1alpha1.Source{
+			Revision: &emptyString,
+		}},
+		out: buildv1alpha1.BuildSpec{Source: buildv1alpha1.Source{
+			Revision: nil,
+		}},
 	}}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
# Changes

Similar to previous pull requests such as #58, setting value to nil instead of empty string.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Ensure that the Build's `spec.revision` is not set to `""` but rather to `nil`
```