### PR TITLE
 Adds support for img labels and anno. in build create cmd 

### DIFF
--- a/pkg/shp/flags/build.go
+++ b/pkg/shp/flags/build.go
@@ -28,6 +28,8 @@ func BuildSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildSpec {
 		},
 		Output: buildv1alpha1.Image{
 			Credentials: &corev1.LocalObjectReference{},
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
 		},
 		Timeout: &metav1.Duration{},
 	}
@@ -39,6 +41,8 @@ func BuildSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildSpec {
 	imageFlags(flags, "output", &spec.Output)
 	timeoutFlags(flags, spec.Timeout)
 	envFlags(flags, &spec.Env)
+	imageLabelsFlags(flags, spec.Output.Labels)
+	imageAnnotationsFlags(flags, spec.Output.Annotations)
 
 	return spec
 }

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -39,6 +39,8 @@ func TestBuildSpecFromFlags(t *testing.T) {
 		Output: buildv1alpha1.Image{
 			Credentials: &credentials,
 			Image:       "output-image",
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
 		},
 		Timeout: &metav1.Duration{
 			Duration: 1 * time.Second,

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -46,6 +46,10 @@ const (
 	ServiceAccountGenerateFlag = "sa-generate"
 	// TimeoutFlag command-line flag.
 	TimeoutFlag = "timeout"
+	// OutputImageLabelsFlag command-line flag.
+	OutputImageLabelsFlag = "output-image-label"
+	// OutputImageAnnotationsFlag command-line flag.
+	OutputImageAnnotationsFlag = "output-image-annotation"
 )
 
 // sourceFlags flags for ".spec.source"
@@ -172,5 +176,26 @@ func envFlags(flags *pflag.FlagSet, envs *[]corev1.EnvVar) {
 		"env",
 		"e",
 		"specify a key-value pair for an environment variable to set for the build container",
+	)
+}
+
+// imageLabelsFlags registers flags for output image labels.
+func imageLabelsFlags(flags *pflag.FlagSet, labels map[string]string) {
+	flags.VarP(
+		NewMapValue(labels),
+		OutputImageLabelsFlag,
+		"",
+		"specify a set of key-value pairs that correspond to labels to set on the output image",
+	)
+
+}
+
+// imageLabelsFlags registers flags for output image annotations.
+func imageAnnotationsFlags(flags *pflag.FlagSet, annotations map[string]string) {
+	flags.VarP(
+		NewMapValue(annotations),
+		OutputImageAnnotationsFlag,
+		"",
+		"specify a set of key-value pairs that correspond to annotations to set on the output image",
 	)
 }

--- a/pkg/shp/flags/map_value.go
+++ b/pkg/shp/flags/map_value.go
@@ -1,0 +1,43 @@
+package flags
+
+import (
+	"fmt"
+)
+
+// MapValue implements pflag.Value interface, in order to store key-value
+// pairs used on Shipwright's BuildSpec which have map[string]string as field type.
+type MapValue struct {
+	kvMap map[string]string
+}
+
+// String prints out the string representation of the map.
+func (m *MapValue) String() string {
+	slice := []string{}
+	for k, v := range m.kvMap {
+		slice = append(slice, fmt.Sprintf("%s=%s", k, v))
+	}
+	csv, _ := writeAsCSV(slice)
+	return fmt.Sprintf("[%s]", csv)
+}
+
+// Set receives a key-value entry separated by equal sign ("=").
+func (m *MapValue) Set(value string) error {
+	k, v, err := splitKeyValue(value)
+	if err != nil {
+		return err
+	}
+	m.kvMap[k] = v
+	return nil
+}
+
+// Type analogous to the pflag "stringArray" type, where each flag entry will be translated to a
+// single array (slice) entry, therefore the comma (",") is accepted as part of the value, as any
+// other special character.
+func (c *MapValue) Type() string {
+	return "stringArray"
+}
+
+// NewMapValue instantiate a MapValue sharing the map.
+func NewMapValue(m map[string]string) *MapValue {
+	return &MapValue{kvMap: m}
+}

--- a/pkg/shp/flags/map_value_test.go
+++ b/pkg/shp/flags/map_value_test.go
@@ -1,0 +1,44 @@
+package flags
+
+import (
+	"testing"
+
+	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+
+	o "github.com/onsi/gomega"
+)
+
+func TestNewMapValue(t *testing.T) {
+	g := o.NewGomegaWithT(t)
+
+	spec := &buildv1alpha1.BuildSpec{Output: buildv1alpha1.Image{
+		Labels: map[string]string{},
+	}}
+	c := NewMapValue(spec.Output.Labels)
+
+	// expect error when key-value is not split by equal sign
+	err := c.Set("a")
+	g.Expect(err).NotTo(o.BeNil())
+
+	// setting a simple key-value entry
+	err = c.Set("a=b")
+	g.Expect(err).To(o.BeNil())
+	g.Expect(len(spec.Output.Labels)).To(o.Equal(1))
+	g.Expect(spec.Output.Labels["a"]).To(o.Equal("b"))
+
+	// setting a key-value entry with special characters
+	err = c.Set("b=c,d,e=f")
+	g.Expect(err).To(o.BeNil())
+	g.Expect(len(spec.Output.Labels)).To(o.Equal(2))
+	g.Expect(spec.Output.Labels["b"]).To(o.Equal("c,d,e=f"))
+
+	// setting a key-value entry with space on it
+	err = c.Set("c=d e")
+	g.Expect(err).To(o.BeNil())
+	g.Expect(len(spec.Output.Labels)).To(o.Equal(3))
+	g.Expect(spec.Output.Labels["c"]).To(o.Equal("d e"))
+
+	// making sure the string representation produced is as expected
+	s := c.String()
+	g.Expect(s).To(o.Equal("[a=b,\"b=c,d,e=f\",c=d e]"))
+}

--- a/test/e2e/output-image-labels-annotations.bats
+++ b/test/e2e/output-image-labels-annotations.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+source test/e2e/helpers.sh
+
+setup() {
+	load 'bats/support/load'
+	load 'bats/assert/load'
+	load 'bats/file/load'
+}
+
+teardown() {
+	run kubectl delete builds.shipwright.io --all
+	run kubectl delete buildruns.shipwright.io --all
+}
+
+@test "shp output image labels and annotation lifecycle" {
+	# generate random names for our build and buildrun
+	build_name=$(random_name)
+	buildrun_name=$(random_name)
+
+	# create a Build with a label and an annotation
+	run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image --output-image-label=foo=bar --output-image-annotation=created-by=shipwright
+	assert_success
+
+	# ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+	# get the yaml for the Build object
+	run kubectl get builds.shipwright.io/${build_name} -o yaml
+	assert_success
+
+	# ensure that the label and annotation were inserted into the Build object
+	assert_output --partial "foo: bar"
+	assert_output --partial "created-by: shipwright"
+}


### PR DESCRIPTION
This adds support to specify labels and annotation for
output image.
There are 2 flags added for the `build create` command
- output-image-label
- output-image-annotation

Part of #66 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Adds support to specify on Build objects labels and annotations to be set on output images
```
