### PR TITLE
Initialize klog with (go)flags and add these flags to pflag as well

### DIFF
--- a/cmd/shp/main.go
+++ b/cmd/shp/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
 
 	"github.com/shipwright-io/cli/pkg/shp/cmd"
 )
@@ -15,8 +17,8 @@ import (
 const ApplicationName = "shp"
 
 func main() {
-	flags := pflag.NewFlagSet(ApplicationName, pflag.ExitOnError)
-	pflag.CommandLine = flags
+	initGoFlags()
+	initPFlags()
 
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	rootCmd := cmd.NewCmdSHP(&streams)
@@ -24,4 +26,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// initGoFlags initializes the flag sets for klog.
+// Any flags for "-h" or "--help" are ignored because pflag will show the usage later with all subcommands.
+func initGoFlags() {
+	flagset := goflag.NewFlagSet(ApplicationName, goflag.ContinueOnError)
+	goflag.CommandLine = flagset
+	klog.InitFlags(flagset)
+
+	args := []string{}
+	for _, arg := range os.Args[1:] {
+		if arg != "-h" && arg != "--help" {
+			args = append(args, arg)
+		}
+	}
+	flagset.Parse(args)
+}
+
+// initPFlags initializes the pflags used by Cobra subcommands.
+func initPFlags() {
+	flags := pflag.NewFlagSet(ApplicationName, pflag.ExitOnError)
+	flags.AddGoFlagSet(goflag.CommandLine)
+	pflag.CommandLine = flags
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.20.6
 	k8s.io/cli-runtime v0.20.2
 	k8s.io/client-go v0.20.6
+	k8s.io/klog/v2 v2.5.0
 	k8s.io/utils v0.0.0-20210629042839-4a2b36d8d73f
 )
 

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -18,16 +18,58 @@ teardown() {
 	assert_success
 }
 
+@test "shp --help lists all available commands" {
+	run shp --help
+	assert_success
+	assert_line "Available Commands:"
+	assert_line "  build       Manage Builds"
+	assert_line "  buildrun    Manage BuildRuns"
+	assert_line "  completion  generate the autocompletion script for the specified shell"
+	assert_line "  help        Help about any command"
+}
+
+@test "shp --help lists some common flags" {
+	run shp --help
+	assert_success
+	assert_line --regexp "-s, --server string    [ ]+The address and port of the Kubernetes API server"
+	assert_line --regexp "--user string          [ ]+The name of the kubeconfig user to use"
+	assert_line --regexp "--token string         [ ]+Bearer token for authentication to the API server"
+	assert_line --regexp "-n, --namespace string [ ]+If present, the namespace scope for this CLI request"
+}
+
+@test "shp --help lists also logging flags" {
+	run shp --help
+	assert_success
+	assert_line --regexp "-v, --v Level     [ ]+number for the log level verbosity"
+	assert_line --regexp "--log_file string [ ]+If non-empty, use this log file"
+}
+
 @test "shp [build/buildrun] create should not error when a name is specified" {
 	# generate random names for our build and buildrun
-    build_name=$(random_name)
+	build_name=$(random_name)
 	buildrun_name=$(random_name)
 
 	# ensure that shp build create does not give an error when a build_name is specified
-    run shp build create ${build_name} --source-url=url --output-image=image
-    assert_success
+	run shp build create ${build_name} --source-url=url --output-image=image
+	assert_success
 
 	# ensure that shp buildrun create does not give an error when a buildrun_name is specified
-    run shp buildrun create ${buildrun_name} --buildref-name=${build_name}
+	run shp buildrun create ${buildrun_name} --buildref-name=${build_name}
 	assert_success
-}	
+}
+
+@test "shp -v=10 build list can log the kubernetes api communication" {
+	# ensure that shp command doesn't log the api calls by default
+	run shp build list
+	assert_success
+	refute_line --regexp "GET .*/apis/shipwright.io/v1alpha1/namespaces/default/builds"
+	refute_line --partial "Response Headers"
+	refute_line --partial "Response Body"
+
+	# ensure that shp command supports -v loglevel flag.
+	run shp -v=10 build list
+	assert_success
+	assert_line --regexp "GET .*/apis/shipwright.io/v1alpha1/namespaces/default/builds"
+	assert_line --partial "Response Headers"
+	assert_line --partial "Response Body"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -416,6 +416,7 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
 # k8s.io/klog/v2 v2.5.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f
 k8s.io/kube-openapi/pkg/common


### PR DESCRIPTION
# Changes

Just initialize [klog](https://github.com/kubernetes/klog) with go flags and add these flags to pflag as well.

Fixes #7

With this change its possible to enable k8s api communication, for example:

```bash
go run cmd/shp/main.go -v=10 br list

I1029 19:15:17.183378  141455 loader.go:379] Config loaded from file: ...kubeconfig
I1029 19:15:17.184151  141455 round_trippers.go:425] curl -k -v -XGET  -H "Authorization: Bearer <masked>" -H "Accept: application/json, */*" -H "User-Agent: main/v0.0.0 (linux/amd64) kubernetes/$Format" 'https://api.crc.testing:6443/apis/shipwright.io/v1alpha1/namespaces/default/buildruns'
I1029 19:15:17.195693  141455 round_trippers.go:445] GET https://api.crc.testing:6443/apis/shipwright.io/v1alpha1/namespaces/default/buildruns 200 OK in 11 milliseconds

...

NAME                    STATUS
s2i-nodejs-build-rjtz9  Failed
```

Help output shows `klog` attributes as well as all subcommands. See `-v` and all these `--log*` arguments.

```
go run cmd/shp/main.go --help

Command-line client for Shipwright's Build API.

Usage:
  shp [command] [resource] [flags]
  shp [command]

Available Commands:
  build       Manage Builds
  buildrun    Manage BuildRuns
  completion  generate the autocompletion script for the specified shell
  help        Help about any command

Flags:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files
      --as string                        Username to impersonate for the operation
      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string                 Default cache directory (default "/home/christoph/.kube/cache")
      --certificate-authority string     Path to a cert file for the certificate authority
      --client-certificate string        Path to a client certificate file for TLS
      --client-key string                Path to a client key file for TLS
      --cluster string                   The name of the kubeconfig cluster to use
      --context string                   The name of the kubeconfig context to use
  -h, --help                             help for shp
      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --log_file string                  If non-empty, use this log file
      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
  -n, --namespace string                 If present, the namespace scope for this CLI request
      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level
      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                    The address and port of the Kubernetes API server
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                     Bearer token for authentication to the API server
      --user string                      The name of the kubeconfig user to use
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "shp [command] --help" for more information about a command.
```

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Initialize klog, this enable users to customize k8s api logging with -v and --log* arguments.
```
