### PR TITLE
Fixes create cmds to return an error if env passed is invalid

### DIFF
--- a/pkg/shp/cmd/build/create.go
+++ b/pkg/shp/cmd/build/create.go
@@ -62,11 +62,15 @@ func (c *CreateCommand) Run(params *params.Params, io *genericclioptions.IOStrea
 		Spec: *c.buildSpec,
 	}
 
-	envs, err := c.cmd.Flags().GetStringArray("env")
+	envs, err := c.cmd.Flags().GetStringArray(flags.EnvFlag)
 	if err != nil {
 		return err
 	}
-	b.Spec.Env = append(b.Spec.Env, util.StringSliceToEnvVarSlice(envs)...)
+	parsedEnvs, err := util.StringSliceToEnvVarSlice(envs)
+	if err != nil {
+		return err
+	}
+	b.Spec.Env = append(b.Spec.Env, parsedEnvs...)
 
 	flags.SanitizeBuildSpec(&b.Spec)
 

--- a/pkg/shp/cmd/buildrun/create.go
+++ b/pkg/shp/cmd/buildrun/create.go
@@ -63,11 +63,15 @@ func (c *CreateCommand) Run(params *params.Params, ioStreams *genericclioptions.
 		Spec: *c.buildRunSpec,
 	}
 
-	envs, err := c.cmd.Flags().GetStringArray("env")
+	envs, err := c.cmd.Flags().GetStringArray(flags.EnvFlag)
 	if err != nil {
 		return err
 	}
-	br.Spec.Env = append(br.Spec.Env, util.StringSliceToEnvVarSlice(envs)...)
+	parsedEnvs, err := util.StringSliceToEnvVarSlice(envs)
+	if err != nil {
+		return err
+	}
+	br.Spec.Env = append(br.Spec.Env, parsedEnvs...)
 
 	flags.SanitizeBuildRunSpec(&br.Spec)
 

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -170,7 +170,7 @@ func envFlags(flags *pflag.FlagSet, envs []corev1.EnvVar) {
 	var e []string
 	flags.StringArrayVarP(
 		&e,
-		"env",
+		EnvFlag,
 		"e",
 		[]string{},
 		"specify a key-value pair for an environment variable to set for the build container",

--- a/pkg/shp/reactor/pod_watcher.go
+++ b/pkg/shp/reactor/pod_watcher.go
@@ -26,9 +26,9 @@ type PodWatcher struct {
 	stopLock    sync.Mutex
 	stopped     bool
 	eventTicker *time.Ticker
-	clientset kubernetes.Interface
-	listOpts  metav1.ListOptions
-	ns string
+	clientset   kubernetes.Interface
+	listOpts    metav1.ListOptions
+	ns          string
 	watcher     watch.Interface // client watch instance
 
 	noPodEventsYetFn NoPodEventsYetFn

--- a/pkg/shp/reactor/pod_watcher_test.go
+++ b/pkg/shp/reactor/pod_watcher_test.go
@@ -71,7 +71,6 @@ func Test_PodWatcher_NotCalledYet(t *testing.T) {
 		eventsCh <- true
 	})
 
-
 	// executing the event loop in the background, and waiting for the stop channel before inspecting
 	// for errors
 	go func() {

--- a/pkg/shp/util/env.go
+++ b/pkg/shp/util/env.go
@@ -1,17 +1,22 @@
 package util
 
 import (
+	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
-func StringSliceToEnvVarSlice(envs []string) []corev1.EnvVar {
+func StringSliceToEnvVarSlice(envs []string) ([]corev1.EnvVar, error) {
 	envVars := []corev1.EnvVar{}
 
-	for _, e := range envs {
-		d := strings.Split(e, "=")
-		envVars = append(envVars, corev1.EnvVar{Name: d[0], Value: d[1]})
+	for _, l := range envs {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) == 1 {
+			return envVars, fmt.Errorf("failed to parse key-value pair %q, not enough parts", l)
+		}
+		envVars = append(envVars, corev1.EnvVar{Name: parts[0], Value: parts[1]})
 	}
-	return envVars
+
+	return envVars, nil
 }

--- a/pkg/shp/util/env_test.go
+++ b/pkg/shp/util/env_test.go
@@ -46,8 +46,32 @@ func TestStringSliceToEnvVar(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := StringSliceToEnvVarSlice(tt.args.envs); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := StringSliceToEnvVarSlice(tt.args.envs); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("StringSliceToEnvVar() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringSliceToEnvVar_ErrorCases(t *testing.T) {
+	type args struct {
+		envs []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "value part missing",
+			args: args{
+				envs: []string{"abc"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := StringSliceToEnvVarSlice(tt.args.envs); err == nil {
+				t.Errorf("StringSliceToEnvVarSlice() = want error but got nil")
 			}
 		})
 	}


### PR DESCRIPTION
If we pass an env which is not a valid key-value pair, cli breaks.
this handles that parsing of passed string and returns an error
if passed env is not in key=value pattern.

Ref https://github.com/shipwright-io/cli/pull/68#discussion_r739153809

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
Fixes create cmd to return an error if env passed is not a valid key value pair
```