### PR TITLE
Adds support for img labels and anno. in buildrun create cmd

### DIFF
--- a/pkg/shp/flags/buildrun.go
+++ b/pkg/shp/flags/buildrun.go
@@ -19,6 +19,8 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildRunSpec {
 		Timeout: &metav1.Duration{},
 		Output: &buildv1alpha1.Image{
 			Credentials: &corev1.LocalObjectReference{},
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
 		},
 		Env: []corev1.EnvVar{},
 	}
@@ -28,6 +30,8 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildRunSpec {
 	timeoutFlags(flags, spec.Timeout)
 	imageFlags(flags, "output", spec.Output)
 	envFlags(flags, &spec.Env)
+	imageLabelsFlags(flags, spec.Output.Labels)
+	imageAnnotationsFlags(flags, spec.Output.Annotations)
 
 	return spec
 }

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -30,6 +30,8 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 		Output: &buildv1alpha1.Image{
 			Credentials: &corev1.LocalObjectReference{Name: "name"},
 			Image:       str,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
 		},
 	}
 

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -187,7 +187,6 @@ func imageLabelsFlags(flags *pflag.FlagSet, labels map[string]string) {
 		"",
 		"specify a set of key-value pairs that correspond to labels to set on the output image",
 	)
-
 }
 
 // imageLabelsFlags registers flags for output image annotations.


### PR DESCRIPTION
This adds support to specify labels and annotation for
output image.
There are 2 flags added for the build create command

    output-image-label
    output-image-annotation

Closes #66 

Also, addresses some left over comments from https://github.com/shipwright-io/cli/pull/68 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Adds support to specify labels and annotations on BuildRun objects to be set on output images
```