### PR TITLE
adjust shp build run -F e2e so that buildpacks build actually fully completes successfully

### DIFF
--- a/test/e2e/run-follow.bats
+++ b/test/e2e/run-follow.bats
@@ -19,34 +19,26 @@ teardown() {
   	buildrun_name=$(random_name)
 
     # create a Build with two environment variables
-    run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image
+    run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --source-context-dir=source-build --output-image=registry.registry.svc.cluster.local:32222/shipwright-io/build-e2e
     assert_success
 
     # initiate a BuildRun with -F
     run shp build run ${build_name} -F
-    #assert_success
-    #TODO
-    # currently do not check success because the create build sample I pulled from either of the existing e2e's do
-    # not run to success, both locally and CI; for the one pulled from envvars:
-    #     [build-and-push] ERROR: No buildpack groups passed detection.
-    #     [build-and-push] ERROR: Please check that you are running against the correct path.
-    #     [build-and-push] ERROR: failed to detect: no buildpacks participating
-    # ideally, we pull additional items from shipwright-io/build and sort that out, as it uses https://github.com/shipwright-io/sample-go.
-    # All that said, the key element for this e2e, log following, is still verifiable
-
+    assert_success
 
     # confirm output that would only exist if following BuildRun logs
     assert_output --partial "[source-default]"
     assert_output --partial "[place-tools]"
     assert_output --partial "[build-and-push]"
+    assert_output --partial "has succeeded!"
 
     # initiate a BuildRun with --follow
     run shp build run ${build_name} --follow
-    #TODO see above
-    #assert_success
+    assert_success
 
      # confirm output that would only exist if following BuildRun logs
      assert_output --partial "[source-default]"
      assert_output --partial "[place-tools]"
      assert_output --partial "[build-and-push]"
+     assert_output --partial "has succeeded!"
 }


### PR DESCRIPTION
# Changes

Fixes #57

/kind cleanup

# Submitter Checklist

- [ /] Includes tests if functionality changed/was added
- [ n/a] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ /] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

