### PR TITLE
update pod watcher to handle all events occurring before the pod watcher is started

### DIFF
--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -205,7 +205,7 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 			pod.Status.Phase = test.phase
 			cmd.follower.OnEvent(pod)
 		} else {
-			cmd.follower.OnNoPodEventsYet()
+			cmd.follower.OnNoPodEventsYet(nil)
 		}
 		checkLog(test.name, test.logText, cmd, out, t)
 	}

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -231,7 +231,7 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 			pod.Status.Phase = test.phase
 			cmd.follower.OnEvent(pod)
 		} else {
-			cmd.follower.OnNoPodEventsYet()
+			cmd.follower.OnNoPodEventsYet(nil)
 		}
 		checkLog(test.name, test.logText, cmd, out, t)
 	}


### PR DESCRIPTION

# Changes

This the the PR I promised in https://github.com/shipwright-io/cli/pull/89#issuecomment-1015473951 around the outcome of the discussion @otaviof and I around the admittedly very small timing window around missing pod events when we instantiate the `Follower` after a `BuildRun` is started, which was desired in the case where we utilized the feature to auto generate the `BuildRun` name.

This conceptually is analogous to the "relist" concept you see in k8s controllers to address the possibility of missing watch events.

/kind cleanup

# Submitter Checklist

- [ /] Includes tests if functionality changed/was added
- [n/a ] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [/ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add a form of relist on the pod watcher to help provide diagnostics for BuildRuns that fail very quickly
```


