### PR TITLE
Add version cmd

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
-  - -s -w -extldflags "-static"
+  - -s -w -extldflags "-static" -X github.com/shipwright-io/cli/pkg/shp/cmd/version.version={{.Version}}
   main: ./cmd/shp/main.go
   binary: shp
 archives:

--- a/docs/shp_version.md
+++ b/docs/shp_version.md
@@ -1,12 +1,18 @@
-## shp
+## shp version
 
-Command-line client for Shipwright's Build API.
+version
 
 ```
-shp [command] [resource] [flags]
+shp version [flags]
 ```
 
 ### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
 
 ```
       --as string                      Username to impersonate for the operation
@@ -17,7 +23,6 @@ shp [command] [resource] [flags]
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
-  -h, --help                           help for shp
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
@@ -30,7 +35,5 @@ shp [command] [resource] [flags]
 
 ### SEE ALSO
 
-* [shp build](shp_build.md)	 - Manage Builds
-* [shp buildrun](shp_buildrun.md)	 - Manage BuildRuns
-* [shp version](shp_version.md)	 - version
+* [shp](shp.md)	 - Command-line client for Shipwright's Build API.
 

--- a/pkg/shp/cmd/root.go
+++ b/pkg/shp/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shipwright-io/cli/pkg/shp/cmd/build"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/buildrun"
+	"github.com/shipwright-io/cli/pkg/shp/cmd/version"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 	"github.com/shipwright-io/cli/pkg/shp/suggestion"
 )
@@ -22,7 +23,7 @@ var rootCmd = &cobra.Command{
 func NewCmdSHP(ioStreams *genericclioptions.IOStreams) *cobra.Command {
 	p := params.NewParams()
 	p.AddFlags(rootCmd.PersistentFlags())
-
+	rootCmd.AddCommand(version.Command())
 	rootCmd.AddCommand(build.Command(p, ioStreams))
 	rootCmd.AddCommand(buildrun.Command(p, ioStreams))
 

--- a/pkg/shp/cmd/version/version.go
+++ b/pkg/shp/cmd/version/version.go
@@ -1,0 +1,30 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version string
+
+// Command returns Version subcommand of Shipwright CLI
+// for retrieving the shp version
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   "version",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if version == "" {
+				version = "development"
+			}
+
+			fmt.Printf("version: %s\n", version)
+		},
+	}
+	return command
+}


### PR DESCRIPTION
# Changes

Enable users to see a version on the ship binary. This will be only set when consuming a ship from our releases.

This adds a new main cmd and the necessary changes in the goreleaser to compile the binary with the current version(_based on the latest git tag_).


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE


# Release Notes

```release-note
Add version cmd.
```

