### PR TITLE
Optional Source URL

### DIFF
--- a/pkg/shp/cmd/build/create.go
+++ b/pkg/shp/cmd/build/create.go
@@ -85,9 +85,6 @@ func createCmd() runner.SubCommand {
 	// instantiating command-line flags and the build-spec structure which receives the informed flag
 	// values, also marking certain flags as mandatory
 	buildSpecFlags := flags.BuildSpecFromFlags(cmd.Flags())
-	if err := cmd.MarkFlagRequired(flags.SourceURLFlag); err != nil {
-		panic(err)
-	}
 	if err := cmd.MarkFlagRequired(flags.OutputImageFlag); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Changes

Making `--source-url` optional for `shp build create`.

Fixes #100 

# Submitter Checklist

- [x] ~Includes tests if functionality changed/was added~
- [x] ~Includes docs if changes are user-facing~
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
Making --source-url optional for `shp build create` subcommand.
```
-->
