### PR TITLE
Hide Kubernetes and Logging flags

### DIFF
--- a/cmd/shp/main.go
+++ b/cmd/shp/main.go
@@ -18,6 +18,22 @@ import (
 // ApplicationName application name.
 const ApplicationName = "shp"
 
+var hiddenLogFlags = []string{
+	"add_dir_header",
+	"alsologtostderr",
+	"log_backtrace_at",
+	"log_dir",
+	"log_file",
+	"log_file_max_size",
+	"logtostderr",
+	"one_output",
+	"skip_headers",
+	"skip_log_headers",
+	"stderrthreshold",
+	"v",
+	"vmodule",
+}
+
 func main() {
 	initGoFlags()
 	initPFlags()
@@ -51,4 +67,10 @@ func initPFlags() {
 	flags := pflag.NewFlagSet(ApplicationName, pflag.ExitOnError)
 	flags.AddGoFlagSet(goflag.CommandLine)
 	pflag.CommandLine = flags
+
+	for _, flag := range hiddenLogFlags {
+		if err := flags.MarkHidden(flag); err != nil {
+			panic(err)
+		}
+	}
 }

--- a/docs/shp.md
+++ b/docs/shp.md
@@ -9,23 +9,10 @@ shp [command] [resource] [flags]
 ### Options
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-  -h, --help                           help for shp
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+  -h, --help                     help for shp
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_build.md
+++ b/docs/shp_build.md
@@ -15,22 +15,9 @@ shp build [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -39,22 +39,9 @@ shp build create <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_build_delete.md
+++ b/docs/shp_build_delete.md
@@ -16,22 +16,9 @@ shp build delete <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_build_list.md
+++ b/docs/shp_build_list.md
@@ -16,22 +16,9 @@ shp build list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -35,22 +35,9 @@ shp build run <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -40,22 +40,9 @@ shp build upload <build-name> [path/to/source|.] [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_buildrun.md
+++ b/docs/shp_buildrun.md
@@ -15,22 +15,9 @@ shp buildrun [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_buildrun_cancel.md
+++ b/docs/shp_buildrun_cancel.md
@@ -15,22 +15,9 @@ shp buildrun cancel <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -34,22 +34,9 @@ shp buildrun create <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_buildrun_delete.md
+++ b/docs/shp_buildrun_delete.md
@@ -15,22 +15,9 @@ shp buildrun delete <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_buildrun_list.md
+++ b/docs/shp_buildrun_list.md
@@ -16,22 +16,9 @@ shp buildrun list [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_buildrun_logs.md
+++ b/docs/shp_buildrun_logs.md
@@ -16,22 +16,9 @@ shp buildrun logs <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/docs/shp_version.md
+++ b/docs/shp_version.md
@@ -15,22 +15,9 @@ shp version [flags]
 ### Options inherited from parent commands
 
 ```
-      --as string                      Username to impersonate for the operation
-      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default cache directory (default "~/.kube/cache")
-      --certificate-authority string   Path to a cert file for the certificate authority
-      --client-certificate string      Path to a client certificate file for TLS
-      --client-key string              Path to a client key file for TLS
-      --cluster string                 The name of the kubeconfig cluster to use
-      --context string                 The name of the kubeconfig context to use
-      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string               If present, the namespace scope for this CLI request
-      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                  The address and port of the Kubernetes API server
-      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                   Bearer token for authentication to the API server
-      --user string                    The name of the kubeconfig user to use
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, the namespace scope for this CLI request
+      --request-timeout string   The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
 ```
 
 ### SEE ALSO

--- a/pkg/shp/params/params.go
+++ b/pkg/shp/params/params.go
@@ -21,6 +21,22 @@ import (
 	"github.com/spf13/pflag"
 )
 
+var hiddenKubeFlags = []string{
+	"as",
+	"as-group",
+	"cache-dir",
+	"certificate-authority",
+	"client-certificate",
+	"client-key",
+	"cluster",
+	"context",
+	"insecure-skip-tls-verify",
+	"server",
+	"tls-server-name",
+	"token",
+	"user",
+}
+
 // Params is a place for Shipwright CLI to store its runtime parameters including configured dynamic
 // client and global flags.
 type Params struct {
@@ -36,6 +52,12 @@ type Params struct {
 // AddFlags accepts flags and adds program global flags to it
 func (p *Params) AddFlags(flags *pflag.FlagSet) {
 	p.configFlags.AddFlags(flags)
+
+	for _, flag := range hiddenKubeFlags {
+		if err := flags.MarkHidden(flag); err != nil {
+			panic(err)
+		}
+	}
 }
 
 // RESTConfig returns the rest configuration based on local flags.

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -28,20 +28,21 @@ teardown() {
 	assert_line "  help        Help about any command"
 }
 
-@test "shp --help lists some common flags" {
+@test "shp --help lists some Kubernetes flags" {
 	run shp --help
 	assert_success
-	assert_line --regexp "-s, --server string    [ ]+The address and port of the Kubernetes API server"
-	assert_line --regexp "--user string          [ ]+The name of the kubeconfig user to use"
-	assert_line --regexp "--token string         [ ]+Bearer token for authentication to the API server"
-	assert_line --regexp "-n, --namespace string [ ]+If present, the namespace scope for this CLI request"
+	assert_line --regexp "--kubeconfig string      [ ]+Path to the kubeconfig file to use for CLI requests."
+	assert_line --regexp "-n, --namespace string   [ ]+If present, the namespace scope for this CLI request"
+	assert_line --regexp "--request-timeout string [ ]+The length of time to wait before giving up on a single server request. Non-zero"
+	refute_output --partial cache-dir
+	refute_output --partial tls-server-name
 }
 
-@test "shp --help lists also logging flags" {
+@test "shp --help lists no logging flags" {
 	run shp --help
 	assert_success
-	assert_line --regexp "-v, --v Level     [ ]+number for the log level verbosity"
-	assert_line --regexp "--log_file string [ ]+If non-empty, use this log file"
+	refute_output --partial log_dir
+	refute_output --partial log_file
 }
 
 @test "shp [build/buildrun] create should not error when a name is specified" {


### PR DESCRIPTION
# Changes

Hiding the logging flags, and the Kubernetes connection flags as discussed in issue #99. Keeping `kubeconfig`, `namespace`, and `request-timeout` visible.

Fixes #99

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```