### PR TITLE
Add retention flags

### DIFF
--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -17,23 +17,27 @@ shp build create <name> [flags]
 ### Options
 
 ```
-      --builder-credentials-secret string     name of the secret with builder-image pull credentials
-      --builder-image string                  image employed during the building process
-      --dockerfile string                     path to dockerfile relative to repository
-  -e, --env stringArray                       specify a key-value pair for an environment variable to set for the build container (default [])
-  -h, --help                                  help for create
-      --output-credentials-secret string      name of the secret with builder-image pull credentials
-      --output-image string                   image employed during the building process
-      --output-image-annotation stringArray   specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
-      --output-image-label stringArray        specify a set of key-value pairs that correspond to labels to set on the output image (default [])
-      --source-context-dir string             use a inner directory as context directory
-      --source-credentials-secret string      name of the secret with git repository credentials
-      --source-revision string                git repository source revision
-      --source-url string                     git repository source URL
-      --strategy-apiversion string            kubernetes api-version of the build-strategy resource (default "v1alpha1")
-      --strategy-kind string                  build-strategy kind (default "ClusterBuildStrategy")
-      --strategy-name string                  build-strategy name (default "buildpacks-v3")
-      --timeout duration                      build process timeout
+      --builder-credentials-secret string        name of the secret with builder-image pull credentials
+      --builder-image string                     image employed during the building process
+      --dockerfile string                        path to dockerfile relative to repository
+  -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
+  -h, --help                                     help for create
+      --output-credentials-secret string         name of the secret with builder-image pull credentials
+      --output-image string                      image employed during the building process
+      --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
+      --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --retention-failed-limit uint              number of failed BuildRuns to be kept (default 65535)
+      --retention-succeeded-limit uint           number of succeeded BuildRuns to be kept (default 65535)
+      --retention-ttl-after-failed duration      duration to delete a failed BuildRun after completion
+      --retention-ttl-after-succeeded duration   duration to delete a succeeded BuildRun after completion
+      --source-context-dir string                use a inner directory as context directory
+      --source-credentials-secret string         name of the secret with git repository credentials
+      --source-revision string                   git repository source revision
+      --source-url string                        git repository source URL
+      --strategy-apiversion string               kubernetes api-version of the build-strategy resource (default "v1alpha1")
+      --strategy-kind string                     build-strategy kind (default "ClusterBuildStrategy")
+      --strategy-name string                     build-strategy name (default "buildpacks-v3")
+      --timeout duration                         build process timeout
 ```
 
 ### Options inherited from parent commands

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -18,18 +18,20 @@ shp build run <name> [flags]
 ### Options
 
 ```
-      --buildref-apiversion string            API version of build resource to reference
-      --buildref-name string                  name of build resource to reference
-  -e, --env stringArray                       specify a key-value pair for an environment variable to set for the build container (default [])
-  -F, --follow                                Start a build and watch its log until it completes or fails.
-  -h, --help                                  help for run
-      --output-credentials-secret string      name of the secret with builder-image pull credentials
-      --output-image string                   image employed during the building process
-      --output-image-annotation stringArray   specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
-      --output-image-label stringArray        specify a set of key-value pairs that correspond to labels to set on the output image (default [])
-      --sa-generate                           generate a Kubernetes service-account for the build
-      --sa-name string                        Kubernetes service-account name
-      --timeout duration                      build process timeout
+      --buildref-apiversion string               API version of build resource to reference
+      --buildref-name string                     name of build resource to reference
+  -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
+  -F, --follow                                   Start a build and watch its log until it completes or fails.
+  -h, --help                                     help for run
+      --output-credentials-secret string         name of the secret with builder-image pull credentials
+      --output-image string                      image employed during the building process
+      --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
+      --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
+      --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
+      --sa-generate                              generate a Kubernetes service-account for the build
+      --sa-name string                           Kubernetes service-account name
+      --timeout duration                         build process timeout
 ```
 
 ### Options inherited from parent commands

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -23,18 +23,20 @@ shp build upload <build-name> [path/to/source|.] [flags]
 ### Options
 
 ```
-      --buildref-apiversion string            API version of build resource to reference
-      --buildref-name string                  name of build resource to reference
-  -e, --env stringArray                       specify a key-value pair for an environment variable to set for the build container (default [])
-  -F, --follow                                Start a build and watch its log until it completes or fails.
-  -h, --help                                  help for upload
-      --output-credentials-secret string      name of the secret with builder-image pull credentials
-      --output-image string                   image employed during the building process
-      --output-image-annotation stringArray   specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
-      --output-image-label stringArray        specify a set of key-value pairs that correspond to labels to set on the output image (default [])
-      --sa-generate                           generate a Kubernetes service-account for the build
-      --sa-name string                        Kubernetes service-account name
-      --timeout duration                      build process timeout
+      --buildref-apiversion string               API version of build resource to reference
+      --buildref-name string                     name of build resource to reference
+  -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
+  -F, --follow                                   Start a build and watch its log until it completes or fails.
+  -h, --help                                     help for upload
+      --output-credentials-secret string         name of the secret with builder-image pull credentials
+      --output-image string                      image employed during the building process
+      --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
+      --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
+      --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
+      --sa-generate                              generate a Kubernetes service-account for the build
+      --sa-name string                           Kubernetes service-account name
+      --timeout duration                         build process timeout
 ```
 
 ### Options inherited from parent commands

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -18,17 +18,19 @@ shp buildrun create <name> [flags]
 ### Options
 
 ```
-      --buildref-apiversion string            API version of build resource to reference
-      --buildref-name string                  name of build resource to reference
-  -e, --env stringArray                       specify a key-value pair for an environment variable to set for the build container (default [])
-  -h, --help                                  help for create
-      --output-credentials-secret string      name of the secret with builder-image pull credentials
-      --output-image string                   image employed during the building process
-      --output-image-annotation stringArray   specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
-      --output-image-label stringArray        specify a set of key-value pairs that correspond to labels to set on the output image (default [])
-      --sa-generate                           generate a Kubernetes service-account for the build
-      --sa-name string                        Kubernetes service-account name
-      --timeout duration                      build process timeout
+      --buildref-apiversion string               API version of build resource to reference
+      --buildref-name string                     name of build resource to reference
+  -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
+  -h, --help                                     help for create
+      --output-credentials-secret string         name of the secret with builder-image pull credentials
+      --output-image string                      image employed during the building process
+      --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
+      --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
+      --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
+      --sa-generate                              generate a Kubernetes service-account for the build
+      --sa-name string                           Kubernetes service-account name
+      --timeout duration                         build process timeout
 ```
 
 ### Options inherited from parent commands

--- a/pkg/shp/cmd/build/list.go
+++ b/pkg/shp/cmd/build/list.go
@@ -72,7 +72,11 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 	}
 
 	for _, b := range buildList.Items {
-		fmt.Fprintf(writer, columnTemplate, b.Name, b.Spec.Output.Image, b.Status.Message)
+		message := ""
+		if b.Status.Message != nil {
+			message = *b.Status.Message
+		}
+		fmt.Fprintf(writer, columnTemplate, b.Name, b.Spec.Output.Image, message)
 	}
 
 	writer.Flush()

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -35,6 +35,14 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
+		Retention: &buildv1alpha1.BuildRunRetention{
+			TTLAfterFailed: &metav1.Duration{
+				Duration: 48 * time.Hour,
+			},
+			TTLAfterSucceeded: &metav1.Duration{
+				Duration: 30 * time.Minute,
+			},
+		},
 	}
 
 	cmd := &cobra.Command{}
@@ -73,6 +81,20 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 		g.Expect(err).To(BeNil())
 
 		g.Expect(*expected.Output).To(Equal(*spec.Output), "spec.output")
+	})
+
+	t.Run(".spec.retention.ttlAfterFailed", func(t *testing.T) {
+		err := flags.Set(RetentionTTLAfterFailedFlag, expected.Retention.TTLAfterFailed.Duration.String())
+		g.Expect(err).To(BeNil())
+
+		g.Expect(*expected.Retention.TTLAfterFailed).To(Equal(*spec.Retention.TTLAfterFailed), "spec.retention.ttlAfterFailed")
+	})
+
+	t.Run(".spec.retention.ttlAfterSucceeded", func(t *testing.T) {
+		err := flags.Set(RetentionTTLAfterSucceededFlag, expected.Retention.TTLAfterSucceeded.Duration.String())
+		g.Expect(err).To(BeNil())
+
+		g.Expect(*expected.Retention.TTLAfterSucceeded).To(Equal(*spec.Retention.TTLAfterSucceeded), "spec.retention.ttlAfterSucceeded")
 	})
 }
 
@@ -114,6 +136,12 @@ func TestSanitizeBuildRunSpec(t *testing.T) {
 			Duration: time.Duration(0),
 		}},
 		out: buildv1alpha1.BuildRunSpec{Timeout: nil},
+	}, {
+		name: "should clean-up an empty retention",
+		in: buildv1alpha1.BuildRunSpec{
+			Retention: &buildv1alpha1.BuildRunRetention{},
+		},
+		out: buildv1alpha1.BuildRunSpec{},
 	}}
 
 	for _, tt := range testCases {

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -50,6 +50,14 @@ const (
 	OutputImageLabelsFlag = "output-image-label"
 	// OutputImageAnnotationsFlag command-line flag.
 	OutputImageAnnotationsFlag = "output-image-annotation"
+	// RetentionFailedLimitFlag command-line flag.
+	RetentionFailedLimitFlag = "retention-failed-limit"
+	// RetentionSucceededLimitFlag command-line flag.
+	RetentionSucceededLimitFlag = "retention-succeeded-limit"
+	// RetentionTTLAfterFailedFlag command-line flag.
+	RetentionTTLAfterFailedFlag = "retention-ttl-after-failed"
+	// RetentionTTLAfterSucceededFlag command-line flag.
+	RetentionTTLAfterSucceededFlag = "retention-ttl-after-succeeded"
 )
 
 // sourceFlags flags for ".spec.source"
@@ -196,5 +204,47 @@ func imageAnnotationsFlags(flags *pflag.FlagSet, annotations map[string]string) 
 		OutputImageAnnotationsFlag,
 		"",
 		"specify a set of key-value pairs that correspond to annotations to set on the output image",
+	)
+}
+
+func buildRetentionFlags(flags *pflag.FlagSet, buildRetention *buildv1alpha1.BuildRetention) {
+	flags.UintVar(
+		buildRetention.FailedLimit,
+		RetentionFailedLimitFlag,
+		65535,
+		"number of failed BuildRuns to be kept",
+	)
+	flags.UintVar(
+		buildRetention.SucceededLimit,
+		RetentionSucceededLimitFlag,
+		65535,
+		"number of succeeded BuildRuns to be kept",
+	)
+	flags.DurationVar(
+		&buildRetention.TTLAfterFailed.Duration,
+		RetentionTTLAfterFailedFlag,
+		time.Duration(0),
+		"duration to delete a failed BuildRun after completion",
+	)
+	flags.DurationVar(
+		&buildRetention.TTLAfterSucceeded.Duration,
+		RetentionTTLAfterSucceededFlag,
+		time.Duration(0),
+		"duration to delete a succeeded BuildRun after completion",
+	)
+}
+
+func buildRunRetentionFlags(flags *pflag.FlagSet, buildRunRetention *buildv1alpha1.BuildRunRetention) {
+	flags.DurationVar(
+		&buildRunRetention.TTLAfterFailed.Duration,
+		RetentionTTLAfterFailedFlag,
+		time.Duration(0),
+		"duration to delete the BuildRun after it failed",
+	)
+	flags.DurationVar(
+		&buildRunRetention.TTLAfterSucceeded.Duration,
+		RetentionTTLAfterSucceededFlag,
+		time.Duration(0),
+		"duration to delete the BuildRun after it succeeded",
 	)
 }


### PR DESCRIPTION
# Changes

Adding the flags to set the Build and BuildRun retention. And while I was adding flags, I noticed that for some fields that we now intentionally changed to pointers, the cleanup logic to set those fields to `nil` was missing.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
You can now set the retention-related fields when creating a Build, or BuildRun
```