### PR TITLE
fix flakes in log following related unit tests

### DIFF
--- a/pkg/shp/cmd/buildrun/cancel_test.go
+++ b/pkg/shp/cmd/buildrun/cancel_test.go
@@ -97,7 +97,7 @@ func TestCancelBuildRun(t *testing.T) {
 
 		// set up context
 		cmd.Cmd().ExecuteC()
-		param := params.NewParamsForTest(nil, clientset, nil, metav1.NamespaceDefault)
+		param := params.NewParamsForTest(nil, clientset, nil, metav1.NamespaceDefault, nil, nil)
 
 		ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
 		err := cmd.Run(param, &ioStreams)

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -42,7 +42,7 @@ func TestStreamBuildLogs(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset(pod)
 	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
-	param := params.NewParamsForTest(clientset, nil, nil, metav1.NamespaceDefault)
+	param := params.NewParamsForTest(clientset, nil, nil, metav1.NamespaceDefault, nil, nil)
 	err := cmd.Run(param, &ioStreams)
 	if err != nil {
 		t.Fatalf("%s", err.Error())
@@ -180,7 +180,7 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 		if len(test.to) > 0 {
 			pm.Timeout = &test.to
 		}
-		param := params.NewParamsForTest(kclientset, shpclientset, pm, metav1.NamespaceDefault)
+		param := params.NewParamsForTest(kclientset, shpclientset, pm, metav1.NamespaceDefault, nil, nil)
 
 		ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
 

--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -205,6 +205,7 @@ func (f *Follower) OnNoPodEventsYet(podList *corev1.PodList) {
 	br, err := brClient.Get(f.ctx, f.buildRun.Name, metav1.GetOptions{})
 	if err != nil {
 		f.Log(fmt.Sprintf("error accessing BuildRun %q: %s", f.buildRun.Name, err.Error()))
+		f.Stop()
 		return
 	}
 
@@ -225,7 +226,7 @@ func (f *Follower) OnNoPodEventsYet(podList *corev1.PodList) {
 		giveUp = true
 		msg = fmt.Sprintf("BuildRun '%s' has been deleted.\n", br.Name)
 	case !br.HasStarted():
-		f.Log(fmt.Sprintf("BuildRun '%s' has been marked as failed.\n", br.Name))
+		f.Log(fmt.Sprintf("BuildRun '%s' has not been marked as started yet.\n", br.Name))
 	}
 	if giveUp {
 		f.Log(msg)

--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -37,6 +37,9 @@ type Follower struct {
 
 	logLock             sync.Mutex // avoiding race condition to print logs
 	enteredRunningState bool       // target pod is running
+
+	failPollInterval time.Duration // for use in the PollInterval call when processing failed pods
+	failPollTimeout  time.Duration // for use in the PollInterval call when processing failed pods
 }
 
 // NewFollower returns a Follower instance.
@@ -56,9 +59,11 @@ func NewFollower(
 		clientset:      clientset,
 		buildClientset: buildClientset,
 
-		logTail:         tail.NewTail(ctx, clientset),
-		logLock:         sync.Mutex{},
-		tailLogsStarted: map[string]bool{},
+		logTail:          tail.NewTail(ctx, clientset),
+		logLock:          sync.Mutex{},
+		tailLogsStarted:  map[string]bool{},
+		failPollInterval: 1 * time.Second,
+		failPollTimeout:  15 * time.Second,
 	}
 
 	f.pw.WithOnPodModifiedFn(f.OnEvent)
@@ -66,6 +71,23 @@ func NewFollower(
 	f.pw.WithNoPodEventsYetFn(f.OnNoPodEventsYet)
 
 	return f
+}
+
+// SetBuildRunName allows for setting of the BuildRun name after to call to NewFollower.  This help service
+// auto generation of the BuildRun name from the Build.  NOTE, if the BuildRun name
+// is not set prior to the call to WaitForCompletion, the Follower will not function fully once events arrive.
+func (f *Follower) SetBuildRunName(brName types.NamespacedName) {
+	f.buildRun = brName
+}
+
+// SetFailPollInterval overrides the default value used in polling calls
+func (f *Follower) SetFailPollInterval(t time.Duration) {
+	f.failPollInterval = t
+}
+
+// SetFailPollTimeout overrides the default value used in polling calls
+func (f *Follower) SetFailPollTimeout(t time.Duration) {
+	f.failPollTimeout = t
 }
 
 // GetLogLock returns the mutex used for coordinating access to log buffers.
@@ -106,16 +128,20 @@ func (f *Follower) OnEvent(pod *corev1.Pod) error {
 	case corev1.PodRunning:
 		if !f.enteredRunningState {
 			f.Log(fmt.Sprintf("Pod %q in %q state, starting up log tail", pod.GetName(), corev1.PodRunning))
-			f.enteredRunningState = true
-			// graceful time to wait for container start
-			time.Sleep(3 * time.Second)
-			// start tailing container logs
-			f.tailLogs(pod)
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.State.Running != nil && !c.State.Running.StartedAt.IsZero() {
+					f.enteredRunningState = true
+					break
+				}
+			}
+			if f.enteredRunningState {
+				f.tailLogs(pod)
+			}
 		}
 	case corev1.PodFailed:
 		msg := ""
 		var br *buildv1alpha1.BuildRun
-		err := wait.PollImmediate(1*time.Second, 15*time.Second, func() (done bool, err error) {
+		err := wait.PollImmediate(f.failPollInterval, f.failPollTimeout, func() (done bool, err error) {
 			brClient := f.buildClientset.ShipwrightV1alpha1().BuildRuns(pod.Namespace)
 			br, err = brClient.Get(f.ctx, f.buildRun.Name, metav1.GetOptions{})
 			if err != nil {
@@ -235,7 +261,20 @@ func (f *Follower) OnNoPodEventsYet(podList *corev1.PodList) {
 	}
 }
 
-// Start initiates the log following for the referenced BuildRun's Pod
-func (f *Follower) Start(lo metav1.ListOptions) (*corev1.Pod, error) {
-	return f.pw.Start(lo)
+func (f *Follower) Connect(lo metav1.ListOptions) error {
+	return f.pw.Connect(lo)
+}
+
+// WaitForCompletion initiates the log following for the referenced BuildRun's Pod
+func (f *Follower) WaitForCompletion() (*corev1.Pod, error) {
+	return f.pw.WaitForCompletion()
+}
+
+// Start is a convenience method for capturing the use of both Connect and WaitForCompletion
+func (f *Follower) Start(listOpts metav1.ListOptions) (*corev1.Pod, error) {
+	err := f.Connect(listOpts)
+	if err != nil {
+		return nil, err
+	}
+	return f.WaitForCompletion()
 }

--- a/pkg/shp/params/params.go
+++ b/pkg/shp/params/params.go
@@ -48,6 +48,9 @@ type Params struct {
 
 	configFlags *genericclioptions.ConfigFlags
 	namespace   string
+
+	failPollInterval *time.Duration
+	failPollTimeout  *time.Duration
 }
 
 // AddFlags accepts flags and adds program global flags to it
@@ -181,6 +184,12 @@ func (p *Params) NewFollower(
 	}
 
 	p.follower = follower.NewFollower(ctx, br, ioStreams, pw, clientset, buildClientset)
+	if p.failPollTimeout != nil {
+		p.follower.SetFailPollTimeout(*p.failPollTimeout)
+	}
+	if p.failPollInterval != nil {
+		p.follower.SetFailPollInterval(*p.failPollInterval)
+	}
 	return p.follower, nil
 }
 
@@ -198,11 +207,16 @@ func NewParamsForTest(clientset kubernetes.Interface,
 	shpClientset buildclientset.Interface,
 	configFlags *genericclioptions.ConfigFlags,
 	namespace string,
+	failPollInterval *time.Duration,
+	failPollTimeout *time.Duration,
+
 ) *Params {
 	return &Params{
-		clientset:      clientset,
-		buildClientset: shpClientset,
-		configFlags:    configFlags,
-		namespace:      namespace,
+		clientset:        clientset,
+		buildClientset:   shpClientset,
+		configFlags:      configFlags,
+		namespace:        namespace,
+		failPollInterval: failPollInterval,
+		failPollTimeout:  failPollTimeout,
 	}
 }


### PR DESCRIPTION
# Changes

Fixes #103

/kind cleanup

Hello @otaviof @HeavyWombat @SaschaSchwarze0 

I *finally* got some shipwright cycles this week, and one of my long standing to-do's was to spend quality time on the log following unit test flakes @otaviof reported.

Allow me to explain my process to getting to this point of an alternative PR.

While, as it is clear to see, I initially took a brief pass at reviewing @otaviof 's #104 a month ago, I decided to re-engage here by first making sure I understood first hand what was the crux of the original situation as I remember @otaviof describing in our team meetings, where if I were to attempt to summarize, it was the inherent fragility of k8s fake clients, especially around watches (of course @otaviof please do chime in if my brief summary misses key points).

So running @otaviof 's reproducers in #103 as well as running the unit tests in the debugger, the k8s fake client watch fragility is what was most noticeable to me.  If I were to attempt to summarize, it did not seem thread safe.  To the point where it was unclear if the events reported by the unit test as missing were the actual events that were missing.

But even of more importance, the "has synced" concept we have with the k8s watch based informers used in controllers occurred to me as being something that would be useful here (I describe this in more detail in https://github.com/shipwright-io/cli/issues/103#issuecomment-1103224373).  So, building on that to see if that proved valid (which it did), after about a full day of coding, I've got a different take on addressing this flake with this PR.

I see #104 needs a rebase as it its.  My initial thought is we iterate on this to merge it, so we address the flake. Then reset and see if we want some of the refactoring from #104 that may not be *immediately* related to the k8s fake client flakiness, but that we like,  either by reworking 1#04, and get that ready again, or if it makes sense to just redo #104 in a new PR.  But that said, if folks think of elements of #104 that can be easily applied here, sure, let's discuss.

A more detailed breakdown
- no changes to the existing flags ... the "user experience" is the same 
- follwer/pod_watcher `Start` methonds have been split into `Connect` and `WaitForCompletion` ... this somewhat speaks to the "has synched" concept with k8s informers
- the run command has a `FollowerReady` method to help with multi-threaded use of consumers of the follower (in theory other commands that use follower could follow this pattern if need be) ... this more directly is the "has synched" equivalent from k8s informers
- we have better consistency across the different commands, in that they create or initialize their `Follwers` in their `Complete` methods, and they startup and wait for them in their `Run` methods
- removed the 3 second sleep in the follower event processing
- removed that initialization of the follower in the run unit test 
- added lower level tuning (not exposed as flags at this time) around some of the timing intervals to help speed up unit tests
- removed some of the multi threaded elements in the pod_watcher unit tests; they intermittently stressed the more flaky elements of the k8s fake clients, especially the watch elements; I think in the end, running with race detection, we have sufficient coverage there anyway

Some output from some of @otaviof 's flake reproducers:

```
# Attempt 97...
go test  -race -failfast -timeout=45s  ./pkg/shp/cmd/build -run="^TestStartBuildRunFollowLog"
ok  	github.com/shipwright-io/cli/pkg/shp/cmd/build	0.103s
# Attempt 98...
go test  -race -failfast -timeout=45s  ./pkg/shp/cmd/build -run="^TestStartBuildRunFollowLog"
ok  	github.com/shipwright-io/cli/pkg/shp/cmd/build	0.110s
# Attempt 99...
go test  -race -failfast -timeout=45s  ./pkg/shp/cmd/build -run="^TestStartBuildRunFollowLog"
ok  	github.com/shipwright-io/cli/pkg/shp/cmd/build	0.103s
# Attempt 100...
go test  -race -failfast -timeout=45s  ./pkg/shp/cmd/build -run="^TestStartBuildRunFollowLog"
ok  	github.com/shipwright-io/cli/pkg/shp/cmd/build	0.104s
gmontero ~/go/src/github.com/shipwright-io/cli-1  (k8s-unit-test-flake-impacts-podwatcher)$
```

# Submitter Checklist

- [/ ] Includes tests if functionality changed/was added
- [ n/a] Includes docs if changes are user-facing
- [ /] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [ /] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
