### PR TITLE
Using ObjectMeta.CreationTimestamp as AGE column

### DIFF
--- a/pkg/shp/cmd/buildrun/list.go
+++ b/pkg/shp/cmd/buildrun/list.go
@@ -85,7 +85,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 				break
 			}
 		}
-		age := duration.ShortHumanDuration(time.Since((br.Status.StartTime).Time))
+		age := duration.ShortHumanDuration(time.Since((br.ObjectMeta.CreationTimestamp).Time))
 
 		fmt.Fprintf(writer, columnTemplate, name, status, age)
 	}


### PR DESCRIPTION
# Changes

Fixing #114 by checking if `.Status.StartTime` attribute is `nil`.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] ~Includes docs if changes are user-facing~
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```