### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+    time: "06:00"
+  labels:
+  - kind/dependency-change
+  - release-note-none
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: github.com/shipwright-io/build
+  - dependency-name: github.com/tektoncd/pipeline
+  - dependency-name: k8s.io/*
+  - dependency-name: sigs.k8s.io/*

--- a/.github/workflows/release-notes-linter.yaml
+++ b/.github/workflows/release-notes-linter.yaml
@@ -11,11 +11,8 @@ jobs:
     name: Release Note Linter
     runs-on: ubuntu-latest
     steps:
-      - name: Install wget
-        run: sudo apt-get install wget
-      - name: Install jq
-        run: sudo apt-get install jq
       - name: Sanity Check Release Notes
+        if: github.actor != 'dependabot[bot]'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |


### PR DESCRIPTION
# Changes

Enabling dependabot alerts based on decision in the https://github.com/shipwright-io/community/issues/78.

Settings are explained in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

We explicitely add the release note none label and skip the Release Note Linter action because it is not possible to configure the pull request to contain our required section.

Fixes #113

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```