### PR TITLE
Improve log output when following failing BuildRun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ OUTPUT_HOSTNAME ?= registry.registry.svc.cluster.local:32222
 OUTPUT_NAMESPACE ?= shipwright-io
 
 # Tekton and Shipwright Build Controller versions for CI
-TEKTON_VERSION ?= v0.34.1
-SHIPWRIGHT_VERSION ?= v0.9.0
+TEKTON_VERSION ?= v0.38.3
+SHIPWRIGHT_VERSION ?= v0.10.0
 
 .EXPORT_ALL_VARIABLES:
 

--- a/hack/install-shipwright.sh
+++ b/hack/install-shipwright.sh
@@ -7,7 +7,7 @@ set -eu
 
 SHIPWRIGHT_HOST="github.com"
 SHIPWRIGHT_HOST_PATH="shipwright-io/build/releases/download"
-SHIPWRIGHT_VERSION="${SHIPWRIGHT_VERSION:-v0.9.0}"
+SHIPWRIGHT_VERSION="${SHIPWRIGHT_VERSION:-v0.10.0}"
 
 DEPLOYMENT_TIMEOUT="${DEPLOYMENT_TIMEOUT:-3m}"
 
@@ -24,4 +24,8 @@ kubectl --namespace="shipwright-build" rollout status deployment shipwright-buil
 
 echo "# Installing upstream Build-Strategies..."
 
-kubectl apply -f "https://${SHIPWRIGHT_HOST}/${SHIPWRIGHT_HOST_PATH}/nightly/default_strategies.yaml"
+if [[ ${SHIPWRIGHT_VERSION} == nightly-* ]]; then
+	kubectl apply -f "https://${SHIPWRIGHT_HOST}/${SHIPWRIGHT_HOST_PATH}/nightly/${SHIPWRIGHT_VERSION}-sample-strategies.yaml"
+else
+	kubectl apply -f "https://${SHIPWRIGHT_HOST}/${SHIPWRIGHT_HOST_PATH}/${SHIPWRIGHT_VERSION}/sample-strategies.yaml"
+fi

--- a/hack/install-tekton.sh
+++ b/hack/install-tekton.sh
@@ -5,7 +5,7 @@
 
 set -eu
 
-TEKTON_VERSION="${TEKTON_VERSION:-v0.34.1}"
+TEKTON_VERSION="${TEKTON_VERSION:-v0.38.3}"
 
 TEKTON_HOST="github.com"
 TEKTON_HOST_PATH="tektoncd/pipeline/releases/download"

--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -68,7 +68,7 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 		{
 			name:    "failed-something-else",
 			phase:   corev1.PodFailed,
-			logText: "Pod \"testpod\" has failed!",
+			logText: "BuildRun \"testpod\" has failed.",
 		},
 		{
 			name:  "running",

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -102,7 +102,7 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 		{
 			name:    "failed-something-else",
 			phase:   corev1.PodFailed,
-			logText: "Pod \"testpod\" has failed!",
+			logText: "BuildRun \"testpod\" has failed.",
 		},
 		{
 			name:  "running",

--- a/test/e2e/log-follow--follow.bats
+++ b/test/e2e/log-follow--follow.bats
@@ -36,7 +36,6 @@ teardown() {
 
     # confirm output that would only exist if following BuildRun logs
     assert_output --partial "[source-default]"
-    assert_output --partial "[place-tools]"
     assert_output --partial "[build-and-push]"
     assert_output --partial "has succeeded!"
 }

--- a/test/e2e/log-follow-F.bats
+++ b/test/e2e/log-follow-F.bats
@@ -35,7 +35,6 @@ teardown() {
 
     # confirm output that would only exist if following BuildRun logs
     assert_output --partial "[source-default]"
-    assert_output --partial "[place-tools]"
     assert_output --partial "[build-and-push]"
     assert_output --partial "has succeeded!"
 }

--- a/test/mock/fake_clientset.go
+++ b/test/mock/fake_clientset.go
@@ -2,7 +2,7 @@ package mock
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +44,7 @@ func (f *FakeClientset) Clientset() *kubernetes.Clientset {
 func (f *FakeClientset) roundTripperFn(req *http.Request) (*http.Response, error) {
 	switch method := req.Method; {
 	case method == "GET":
-		body := ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(f.codec, f.pod))))
+		body := io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(f.codec, f.pod))))
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       body,


### PR DESCRIPTION
# Changes

So far, whenever a BuildRun failed, we dumped the whole Pod object. This was imo not usable. One was just about to see the cause of the failure at the end of the logs when it dumps ten meters of mostly unuseful JSON.

Instead, when there is a failed container information in the BuildRun status, then I am only printing its container status. On top I am printing the failure reason and message if available.

e2e is included.

I also updated the test suite to use v0.10 of Shipwright and the recent Tekton version.

This also removes the use of `io/ioutil`, fixes #133 

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
When following the logs of a BuildRun that is failing, you now get improved details at the end.
```