### PR TITLE
Remove emeritus approvers from reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,12 +10,10 @@ approvers:
 
 reviewers:
 - coreydaley
-- sbose78
 - otaviof
 - qu1queee
 - SaschaSchwarze0
 - adambkaplan
-- gabemontero
 - HeavyWombat
 - ImJasonH
 


### PR DESCRIPTION
# Changes

Removing @gabemontero and @sbose78 also from reviewers to prevent them to be asked for a review like in https://github.com/shipwright-io/cli/pull/137.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
