### PR TITLE
Add missing line breaks

### DIFF
--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -127,7 +127,7 @@ func (f *Follower) OnEvent(pod *corev1.Pod) error {
 	switch pod.Status.Phase {
 	case corev1.PodRunning:
 		if !f.enteredRunningState {
-			f.Log(fmt.Sprintf("Pod %q in %q state, starting up log tail", pod.GetName(), corev1.PodRunning))
+			f.Log(fmt.Sprintf("Pod %q in %q state, starting up log tail\n", pod.GetName(), corev1.PodRunning))
 			for _, c := range pod.Status.ContainerStatuses {
 				if c.State.Running != nil && !c.State.Running.StartedAt.IsZero() {
 					f.enteredRunningState = true
@@ -157,7 +157,7 @@ func (f *Follower) OnEvent(pod *corev1.Pod) error {
 			return false, nil
 		})
 		if err != nil {
-			f.Log(fmt.Sprintf("gave up trying to get a buildrun %q in a terminal state for pod %q, proceeding with pod failure processing", f.buildRun.Name, pod.GetName()))
+			f.Log(fmt.Sprintf("gave up trying to get a buildrun %q in a terminal state for pod %q, proceeding with pod failure processing\n", f.buildRun.Name, pod.GetName()))
 		}
 		switch {
 		case br == nil:
@@ -180,12 +180,12 @@ func (f *Follower) OnEvent(pod *corev1.Pod) error {
 		// encountered scenarios where the build run quickly enough that the pod effectively skips the running state,
 		// or the events come in reverse order, and we never enter the tail
 		if !f.enteredRunningState {
-			f.Log(fmt.Sprintf("succeeded event for pod %q arrived before or in place of running event so dumping logs now", pod.GetName()))
+			f.Log(fmt.Sprintf("succeeded event for pod %q arrived before or in place of running event so dumping logs now\n", pod.GetName()))
 			var b strings.Builder
 			for _, c := range pod.Spec.Containers {
 				logs, err := util.GetPodLogs(f.ctx, f.clientset, *pod, c.Name)
 				if err != nil {
-					f.Log(fmt.Sprintf("could not get logs for container %q: %s", c.Name, err.Error()))
+					f.Log(fmt.Sprintf("could not get logs for container %q: %s\n", c.Name, err.Error()))
 					continue
 				}
 				fmt.Fprintf(&b, "*** Pod %q, container %q: ***\n\n", pod.Name, c.Name)
@@ -226,7 +226,7 @@ func (f *Follower) OnNoPodEventsYet(podList *corev1.PodList) {
 	brClient := f.buildClientset.ShipwrightV1alpha1().BuildRuns(f.buildRun.Namespace)
 	br, err := brClient.Get(f.ctx, f.buildRun.Name, metav1.GetOptions{})
 	if err != nil {
-		f.Log(fmt.Sprintf("error accessing BuildRun %q: %s", f.buildRun.Name, err.Error()))
+		f.Log(fmt.Sprintf("error accessing BuildRun %q: %s\n", f.buildRun.Name, err.Error()))
 		f.Stop()
 		return
 	}
@@ -237,22 +237,22 @@ func (f *Follower) OnNoPodEventsYet(podList *corev1.PodList) {
 	switch {
 	case c != nil && c.Status == corev1.ConditionTrue:
 		giveUp = true
-		msg = fmt.Sprintf("BuildRun '%s' has been marked as successful.\n", br.Name)
+		msg = fmt.Sprintf("BuildRun %q has been marked as successful.\n", br.Name)
 	case c != nil && c.Status == corev1.ConditionFalse:
 		giveUp = true
-		msg = fmt.Sprintf("BuildRun '%s' has been marked as failed.\n", br.Name)
+		msg = fmt.Sprintf("BuildRun %q has been marked as failed.\n", br.Name)
 	case br.IsCanceled():
 		giveUp = true
-		msg = fmt.Sprintf("BuildRun '%s' has been canceled.\n", br.Name)
+		msg = fmt.Sprintf("BuildRun %q has been canceled.\n", br.Name)
 	case br.DeletionTimestamp != nil:
 		giveUp = true
-		msg = fmt.Sprintf("BuildRun '%s' has been deleted.\n", br.Name)
+		msg = fmt.Sprintf("BuildRun %q has been deleted.\n", br.Name)
 	case !br.HasStarted():
-		f.Log(fmt.Sprintf("BuildRun '%s' has not been marked as started yet.\n", br.Name))
+		f.Log(fmt.Sprintf("BuildRun %q has not been marked as started yet.\n", br.Name))
 	}
 	if giveUp {
 		f.Log(msg)
-		f.Log(fmt.Sprintf("exiting 'shp build run --follow' for BuildRun %q", br.Name))
+		f.Log(fmt.Sprintf("exiting 'shp build run --follow' for BuildRun %q\n", br.Name))
 		f.Stop()
 	}
 }


### PR DESCRIPTION
# Changes

Just stumbled over a missing line break while running a build with log following:

```
BuildRun "my-buildrun-fx86c" log following has not observed any pod events yet.
BuildRun 'my-buildrun-fx86c' has not been marked as started yet.
Pod "my-buildrun-fx86c-qlgqs-pod" is in state "Pending"...
Pod "my-buildrun-fx86c-qlgqs-pod" is in state "Pending"...
Pod "my-buildrun-fx86c-qlgqs-pod" is in state "Pending"...
Pod "my-buildrun-fx86c-qlgqs-pod" is in state "Pending"...
Pod "my-buildrun-fx86c-qlgqs-pod" is in state "Pending"...
Pod "my-buildrun-fx86c-qlgqs-pod" is in state "Pending"...
Pod "my-buildrun-fx86c-qlgqs-pod" in "Running" state, starting up log tail[prepare] 2022/11/02 19:58:47 Entrypoint initialization
[source-default] 2022/11/02 19:58:54 Info: ssh (/usr/bin/ssh): OpenSSH_8.0p1, OpenSSL 1.1.1k  FIPS 25 Mar 2021
[source-default] 2022/11/02 19:58:54 Info: git (/usr/bin/git): git version 2.31.1
[source-default] 2022/11/02 19:58:54 Info: git-lfs (/usr/bin/git-lfs): git-lfs/2.13.3 (GitHub; linux arm64; go 1.17.5)
```

Note the `Pod "my-buildrun-fx86c-qlgqs-pod" in "Running" state, starting up log tail` line which misses the line break at its end. I went through the code in follow.go and added missing line breaks. Also made the usage of `%q` instead of `'%s'` consistent. The inconsistency can be seen in above example in the first two lines.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```