### PR TITLE
Add kubectl shp for release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,10 @@
+project_name: shp
 before:
   hooks:
   - go generate ./...
 builds:
-- env:
+- id: shp
+  env:
   - CGO_ENABLED=0
   goos:
   - linux
@@ -17,10 +19,41 @@ builds:
   - -s -w -extldflags "-static" -X github.com/shipwright-io/cli/pkg/shp/cmd/version.version={{.Version}}
   main: ./cmd/shp/main.go
   binary: shp
+- id: kubectl-shp
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  flags:
+  - -trimpath
+  ldflags:
+  - -s -w -extldflags "-static" -X github.com/shipwright-io/cli/pkg/shp/cmd/version.version={{.Version}}
+  main: ./cmd/shp/main.go
+  binary: kubectl-shp
 archives:
-- replacements:
-    darwin: macOS
-    amd64: x86_64
+- id: "shp"
+  name_template: >-
+    {{ .ProjectName }}_{{ .Tag }}_
+    {{- if eq .Os "darwin" }}macOS_
+    {{- else }}{{ .Os }}_{{ end }}
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else }}{{ .Arch }}{{ end }}
+  builds:
+  - shp
+- id: "kubectl-shp"
+  name_template: >-
+    kubectl-{{ .ProjectName }}_{{ .Tag }}_
+    {{- if eq .Os "darwin" }}macOS_
+    {{- else }}{{ .Os }}_{{ end }}
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else }}{{ .Arch }}{{ end }}
+  builds:
+  - kubectl-shp
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
# Changes

- Change prefix cli to shp for release 

- Add kubectl plugin of shp for release

- Change `replacements` to `name_template` for archive files

Because `replacements`  will be deleted and it's not correctly working for multiple archives.

Ref from goreleaser:  
https://goreleaser.com/deprecations/?h=replacements#archivesreplacements
```
The replacements will be removed soon from the archives section, as it was never handled correctly when multiple archives were being used, and it also causes confusion in other places.

You can still get the same features by abusing the name_template property.
```


Fixes #179

Related:
- #102


# Tested

gorelease logs:
```shell
• writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/shp_linux_arm64/shp
    • building                                       binary=dist/shp_linux_amd64_v1/shp
    • building                                       binary=dist/shp_darwin_amd64_v1/shp
    • building                                       binary=dist/shp_darwin_arm64/shp
    • building                                       binary=dist/shp_windows_amd64_v1/shp.exe
    • building                                       binary=dist/shp_windows_arm64/shp.exe
    • building                                       binary=dist/kubectl-shp_linux_amd64_v1/kubectl-shp
    • building                                       binary=dist/kubectl-shp_linux_arm64/kubectl-shp
    • building                                       binary=dist/kubectl-shp_darwin_amd64_v1/kubectl-shp
    • building                                       binary=dist/kubectl-shp_darwin_arm64/kubectl-shp
    • building                                       binary=dist/kubectl-shp_windows_amd64_v1/kubectl-shp.exe
    • building                                       binary=dist/kubectl-shp_windows_arm64/kubectl-shp.exe
    • took: 11m27s
  • generating changelog
  • archives
    • creating                                       archive=dist/shp_v0.99.0_linux_arm64.tar.gz
    • creating                                       archive=dist/shp_v0.99.0_linux_x86_64.tar.gz
    • creating                                       archive=dist/shp_v0.99.0_macOS_x86_64.tar.gz
    • creating                                       archive=dist/shp_v0.99.0_macOS_arm64.tar.gz
    • creating                                       archive=dist/shp_v0.99.0_windows_arm64.tar.gz
    • creating                                       archive=dist/shp_v0.99.0_windows_x86_64.tar.gz
    • creating                                       archive=dist/kubectl-shp_v0.99.0_windows_arm64.tar.gz
    • creating                                       archive=dist/kubectl-shp_v0.99.0_linux_x86_64.tar.gz
    • creating                                       archive=dist/kubectl-shp_v0.99.0_linux_arm64.tar.gz
    • creating                                       archive=dist/kubectl-shp_v0.99.0_macOS_x86_64.tar.gz
    • creating                                       archive=dist/kubectl-shp_v0.99.0_macOS_arm64.tar.gz
    • creating                                       archive=dist/kubectl-shp_v0.99.0_windows_x86_64.tar.gz
    • took: 39s
  • calculating checksums
  • publishing
    • scm releases
      • creating or updating release                 repo=liangyuanpeng/shipwright-cli tag=v0.99.0
      • release updated                              name=v0.99.0 release-id=99490864 request-id=2[34](https://github.com/liangyuanpeng/shipwright-cli/actions/runs/4696180341/jobs/8326032835#step:5:35)0:450B:2DB4B57:2EEA3BB:6438D0D6
      • uploading to release                         file=dist/shp_v0.99.0_linux_arm64.tar.gz name=shp_v0.99.0_linux_arm64.tar.gz
      • uploading to release                         file=dist/shp_v0.99.0_linux_x86_64.tar.gz name=shp_v0.99.0_linux_x86_64.tar.gz
      • uploading to release                         file=dist/shp_v0.99.0_macOS_arm64.tar.gz name=shp_v0.99.0_macOS_arm64.tar.gz
      • uploading to release                         file=dist/shp_v0.99.0_macOS_x86_64.tar.gz name=shp_v0.99.0_macOS_x86_64.tar.gz
      • uploading to release                         file=dist/shp_v0.99.0_windows_arm64.tar.gz name=shp_v0.99.0_windows_arm64.tar.gz
      • uploading to release                         file=dist/shp_v0.99.0_windows_x86_64.tar.gz name=shp_v0.99.0_windows_x86_64.tar.gz
      • uploading to release                         file=dist/kubectl-shp_v0.99.0_windows_arm64.tar.gz name=kubectl-shp_v0.99.0_windows_arm64.tar.gz
      • uploading to release                         file=dist/kubectl-shp_v0.99.0_linux_x86_64.tar.gz name=kubectl-shp_v0.99.0_linux_x86_64.tar.gz
      • uploading to release                         file=dist/kubectl-shp_v0.99.0_linux_arm64.tar.gz name=kubectl-shp_v0.99.0_linux_arm64.tar.gz
      • uploading to release                         file=dist/kubectl-shp_v0.99.0_macOS_x86_64.tar.gz name=kubectl-shp_v0.99.0_macOS_x86_64.tar.gz
      • uploading to release                         file=dist/kubectl-shp_v0.99.0_macOS_arm64.tar.gz name=kubectl-shp_v0.99.0_macOS_arm64.tar.gz
      • uploading to release                         file=dist/kubectl-shp_v0.99.0_windows_x86_64.tar.gz name=kubectl-shp_v0.99.0_windows_x86_64.tar.gz
      • uploading to release                         file=dist/checksums.txt name=checksums.txt
      • published                                    url=https://github.com/liangyuanpeng/shipwright-cli/releases/tag/v0.99.0
      • took: 11s
```

More info at https://github.com/liangyuanpeng/shipwright-cli/actions/runs/4696180341/jobs/8326032835

![image](https://user-images.githubusercontent.com/28711504/231950084-117f8b7d-9f73-47e3-9883-31ec27653ad5.png)


# Submitter Checklist

- [ ] ~~Includes tests if functionality changed/was added~~
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)  
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

~~Maybe should be add release note after finished for krew?~~

```release-note
Release kubectl shp binary
```


