### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ usage documentation will come in the near future.
 To install it run:
 
 ```sh
-go get -u github.com/shipwright-io/cli/cmd/shp
+go install github.com/shipwright-io/cli/cmd/shp
 ```
 
 Or clone the repository, and run `make` to build the binary at `_output` directory:


### PR DESCRIPTION
# Changes

`go get` for installing binaries is deprecated, updating to use `go install`

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes



```release-note
NONE
```

