### PR TITLE
Include GitHub Actions version in Dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,12 @@ updates:
   - dependency-name: github.com/tektoncd/pipeline
   - dependency-name: k8s.io/*
   - dependency-name: sigs.k8s.io/*
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+    time: "11:00"
+  labels:
+  - kind/dependency-change
+  - release-note-none
+  open-pull-requests-limit: 10


### PR DESCRIPTION
# Changes

Dependabot will bump actions version automatically.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
