### PR TITLE
Replace `replacements` with `name_template` in GoReleaser configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,8 @@ jobs:
         "${GITHUB_WORKSPACE}/.github/draft_release_notes.sh"
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v5
       with:
-        version: v1.18.2
-        args: release --rm-dist --release-notes /tmp/release-notes/Changes.md
+        args: release --clean --release-notes /tmp/release-notes/Changes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
+---
 before:
   hooks:
   - go generate ./...
+
 builds:
 - env:
   - CGO_ENABLED=0
@@ -17,14 +19,20 @@ builds:
   - -s -w -extldflags "-static" -X github.com/shipwright-io/cli/pkg/shp/cmd/version.version={{.Version}}
   main: ./cmd/shp/main.go
   binary: shp
+
 archives:
-- replacements:
-    darwin: macOS
-    amd64: x86_64
+- name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}macOS{{- else }}{{ .Os }}{{ end -}}_
+      {{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end -}}
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
# Changes

Bump to `goreleaser/goreleaser-action@v5`.

Remove pinned GoReleaser version.

Replaced deprecated `replacements` with a `name_template` to achieve the same output: cli_0.12.0_windows_x86_64.tar.gz
cli_0.12.0_macOS_arm64.tar.gz
cli_0.12.0_linux_x86_64.tar.gz
cli_0.12.0_macOS_x86_64.tar.gz
cli_0.12.0_linux_arm64.tar.gz
cli_0.12.0_windows_arm64.tar.gz

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
