### PR TITLE
SHIP-0038: Add Git Ref to Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       previous-tag:
         description: 'Previous release tag'
         required: true
+      git-ref: 
+        description: 'Git reference for the release. Use an appropriate release-v* branch, tag, or commit SHA.'
+        required: true
 jobs:
   release:
     name: Release
@@ -20,7 +23,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.release }}
+        ref: ${{ inputs.git-ref }}
         fetch-depth: 0
 
     - name: Install Go
@@ -29,11 +32,20 @@ jobs:
         go-version: '1.19.x'
         cache: true
         check-latest: true
+    
+    - name: Tag release
+      run: |
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git tag -a "${{ inputs.release }}" -m "Release ${{ inputs.release }}" --force
+        git push origin "${{ inputs.release }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Release Changelog
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PREVIOUS_TAG: ${{ github.event.inputs.previous-tag }}
+        PREVIOUS_TAG: ${{ inputs.previous-tag }}
       # This creates a set of release notes at Changes.md
       run: |
         export GITHUB_TOKEN


### PR DESCRIPTION
# Changes

Update the release workflow to accept a git reference as a parameter. This will be used to check out the appropriate release branch when generating artifacts and release notes. The workflow then creates a tag for the release, which is required by GoReleaser in a subsequent step.

The action was also updated to use the (new?) inputs context, instead of relying on the inputs key existing in the github.events payload.

Part of #238 

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
