### PR TITLE
Use Go `1.22` in GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: true
         check-latest: true
     - uses: ko-build/setup-ko@v0.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       previous-tag:
         description: 'Previous release tag'
         required: true
-      git-ref: 
+      git-ref:
         description: 'Git reference for the release. Use an appropriate release-v* branch, tag, or commit SHA.'
         required: true
 jobs:
@@ -29,10 +29,10 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21.x'
+        go-version: 1.22.x
         cache: true
         check-latest: true
-    
+
     - name: Tag release
       run: |
         git config --global user.name "${GITHUB_ACTOR}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/shipwright-io/cli
 
-go 1.21
+go 1.22
+
 toolchain go1.22.5
 
 require (


### PR DESCRIPTION
# Changes

Use latest Go version `1.22` for any Go related GitHub Action.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
