### PR TITLE
Remove verbose flag for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG = ./pkg/...
 BIN ?= $(OUTPUT_DIR)/$(APP)
 KUBECTL_BIN ?= $(OUTPUT_DIR)/kubectl-$(APP)
 
-GO_FLAGS ?= -v -mod=vendor
+GO_FLAGS ?= -mod=vendor
 GO_TEST_FLAGS ?= -race -cover
 
 GO_PATH ?= $(shell go env GOPATH)


### PR DESCRIPTION
# Changes

Remove the verbose flag from Go build command, since this doesn't produce helpful output in almost all cases and is just slowing down the build slightly.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
