### PR TITLE
Fix `golangci-lint` findings

### DIFF
--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -3,6 +3,7 @@ package follower
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -201,7 +202,7 @@ func (f *Follower) OnEvent(pod *corev1.Pod) error {
 		for _, c := range pod.Status.Conditions {
 			if c.Type == corev1.PodInitialized || c.Type == corev1.ContainersReady {
 				if c.Status == corev1.ConditionUnknown {
-					return fmt.Errorf(c.Message)
+					return errors.New(c.Message)
 				}
 			}
 		}


### PR DESCRIPTION
# Changes

Finding: printf: non-constant format string in call to fmt.Errorf (govet)

Use `errors.New` instead of `fmt.Errorf` without formatting.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
