### PR TITLE
improved error messaging for Nonexistent namespaces,builds and buildr…

### DIFF
--- a/pkg/shp/cmd/build/list.go
+++ b/pkg/shp/cmd/build/list.go
@@ -63,8 +63,22 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 	if err != nil {
 		return err
 	}
+
+	k8sclient, err := params.ClientSet()
+	if err != nil {
+		return fmt.Errorf("failed to get k8s client: %w", err)
+	}
+	_, err = k8sclient.CoreV1().Namespaces().Get(c.cmd.Context(), params.Namespace(), metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("namespace %s not found. Please ensure that the namespace exists and try again", params.Namespace())
+	}
+
 	if buildList, err = clientset.ShipwrightV1alpha1().Builds(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
 		return err
+	}
+	if len(buildList.Items) == 0 {
+		fmt.Fprintf(io.Out, "No builds found in namespace '%s'. Please initiate a build or verify the namespace.\n", params.Namespace())
+		return nil
 	}
 
 	if !c.noHeader {


### PR DESCRIPTION
# Changes
- Added Improved Error Messaging for Nonexistent Namespaces,Builds and Buildruns in Shipwright CLI
- Fixes #244 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```



