### PR TITLE
Fix `gocritic` findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,5 +3,6 @@ linters:
     - gosec
     - revive
     - misspell
+    - gocritic
   disable:
     - errcheck

--- a/hack/verify-docs.sh
+++ b/hack/verify-docs.sh
@@ -6,6 +6,6 @@
 set -eu -o pipefail
 
 if ( git diff --name-only |grep -q '^docs\/' ) ; then
-	echo "[ERROR] Markdown documenation is out of sync, run 'make generate-docs' and commit the changes!"
+	echo "[ERROR] Markdown documentation is out of sync, run 'make generate-docs' and commit the changes!"
 	exit 1
 fi

--- a/pkg/shp/cmd/buildrun/logs.go
+++ b/pkg/shp/cmd/buildrun/logs.go
@@ -110,8 +110,7 @@ func (c *LogsCommand) Run(params *params.Params, ioStreams *genericclioptions.IO
 		fmt.Fprintf(ioStreams.Out, "Obtaining logs for BuildRun %q\n\n", c.name)
 
 		var b strings.Builder
-		containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
-		for _, container := range containers {
+		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 			logs, err := util.GetPodLogs(c.cmd.Context(), clientset, pod, container.Name)
 			if err != nil {
 				return err

--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -107,8 +107,7 @@ func (f *Follower) Log(msg string) {
 // tailLogs start tailing logs for each container name in init-containers and containers, if not
 // started already.
 func (f *Follower) tailLogs(pod *corev1.Pod) {
-	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
-	for _, container := range containers {
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		if _, exists := f.tailLogsStarted[container.Name]; exists {
 			continue
 		}

--- a/pkg/shp/reactor/pod_watcher.go
+++ b/pkg/shp/reactor/pod_watcher.go
@@ -94,8 +94,6 @@ func (p *PodWatcher) WithNoPodEventsYetFn(fn NoPodEventsYetFn) *PodWatcher {
 
 // handleEvent applies user informed functions against informed pod and event.
 func (p *PodWatcher) handleEvent(pod *corev1.Pod, event watch.Event) error {
-	//p.stopLock.Lock()
-	//defer p.stopLock.Unlock()
 	p.eventTicker.Stop()
 	switch event.Type {
 	case watch.Added:
@@ -235,6 +233,6 @@ func NewPodWatcher(
 	clientset kubernetes.Interface,
 	ns string,
 ) (*PodWatcher, error) {
-	//TODO don't think the have not received events yet ticker needs to be tunable, but leaving a TODO for now while we get feedback
+	// TODO don't think the have not received events yet ticker needs to be tunable, but leaving a TODO for now while we get feedback
 	return &PodWatcher{ctx: ctx, to: timeout, ns: ns, clientset: clientset, eventTicker: time.NewTicker(1 * time.Second), stopCh: make(chan bool), stopLock: sync.Mutex{}}, nil
 }

--- a/pkg/shp/streamer/util.go
+++ b/pkg/shp/streamer/util.go
@@ -18,7 +18,7 @@ func (wc *writeCounter) Write(p []byte) (int, error) {
 }
 
 func trimPrefix(prefix, fpath string) string {
-	return strings.TrimPrefix(strings.Replace(fpath, prefix, "", -1), string(filepath.Separator))
+	return strings.TrimPrefix(strings.ReplaceAll(fpath, prefix, ""), string(filepath.Separator))
 }
 
 func writeFileToTar(tw *tar.Writer, src, fpath string, stat fs.FileInfo) error {

--- a/test/e2e/envvars.bats
+++ b/test/e2e/envvars.bats
@@ -44,15 +44,15 @@ teardown() {
 	run kubectl get buildruns.shipwright.io/${buildrun_name} -o yaml
 	assert_success
 
-	
+
 	# ensure that the environment variables were inserted into the Build object
 	assert_output --partial "VAR_2" && assert_output --partial "buildrun-value-2"
 	assert_output --partial "VAR_3" && assert_output --partial "buildrun-value-3"
 
 	# get the taskrun that we created
-	run kubectl get taskruns.tekton.dev --selector=buildrun.shipwright.io/name=${buildrun_name} -o name 
+	run kubectl get taskruns.tekton.dev --selector=buildrun.shipwright.io/name=${buildrun_name} -o name
 	assert_success
-	
+
 	run kubectl get ${output} -o yaml
 	assert_success
 


### PR DESCRIPTION
# Changes

While working on https://github.com/shipwright-io/cli/pull/291, I realized that my [linter](https://github.com/go-critic/go-critic) returned some minor findings in this repository.

Fix minor TYPO in `hack/verify-docs.sh`.

Resolve `gocritic` findings.

Remove trailing whitespaces.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
