### PR TITLE
Bump Go version to `1.23`

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
         cache: true
         check-latest: true
     - uses: ko-build/setup-ko@v0.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
         cache: true
         check-latest: true
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipwright-io/cli
 
-go 1.22.7
+go 1.23
 
 require (
 	github.com/google/go-containerregistry v0.20.2


### PR DESCRIPTION
# Changes

Bumps the go version in GHA to v1.23

-->

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
