### PR TITLE
add cli changes to move to v1beta1

### DIFF
--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -17,28 +17,25 @@ shp build create <name> [flags]
 ### Options
 
 ```
-      --builder-credentials-secret string        name of the secret with builder-image pull credentials
-      --builder-image string                     image employed during the building process
-      --dockerfile string                        path to dockerfile relative to repository
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-failed-limit uint              number of failed BuildRuns to be kept (default 65535)
       --retention-succeeded-limit uint           number of succeeded BuildRuns to be kept (default 65535)
       --retention-ttl-after-failed duration      duration to delete a failed BuildRun after completion
       --retention-ttl-after-succeeded duration   duration to delete a succeeded BuildRun after completion
-      --source-bundle-image string               source bundle image location, e.g. ghcr.io/shipwright-io/sample-go/source-bundle:latest
-      --source-bundle-prune pruneOption          source bundle prune option, either Never, or AfterPull (default Never)
       --source-context-dir string                use a inner directory as context directory
-      --source-credentials-secret string         name of the secret with credentials to access the source, e.g. git or registry credentials
-      --source-revision string                   git repository source revision
-      --source-url string                        git repository source URL
-      --strategy-apiversion string               kubernetes api-version of the build-strategy resource (default "v1alpha1")
+      --source-git-clone-secret string           name of the secret with credentials to access the git source, e.g. git credentials
+      --source-git-revision string               git repository source revision
+      --source-git-url string                    git repository source URL
+      --source-oci-artifact-image string         source OCI artifact image reference, e.g. ghcr.io/shipwright-io/sample-go/source-bundle:latest
+      --source-oci-artifact-prune pruneOption    source OCI artifact image prune option, either Never, or AfterPull (default Never)
+      --source-oci-artifact-pull-secret string   name of the secret with credentials to access the OCI artifact image, e.g. registry credentials
       --strategy-kind string                     build-strategy kind (default "ClusterBuildStrategy")
       --strategy-name string                     build-strategy name (default "buildpacks-v3")
       --timeout duration                         build process timeout

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -18,20 +18,18 @@ shp build run <name> [flags]
 ### Options
 
 ```
-      --buildref-apiversion string               API version of build resource to reference
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for run
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
       --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
-      --sa-generate                              generate a Kubernetes service-account for the build
       --sa-name string                           Kubernetes service-account name
       --timeout duration                         build process timeout
 ```

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -28,20 +28,18 @@ shp build upload <build-name> [path/to/source|.] [flags]
 ### Options
 
 ```
-      --buildref-apiversion string               API version of build resource to reference
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for upload
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
       --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
-      --sa-generate                              generate a Kubernetes service-account for the build
       --sa-name string                           Kubernetes service-account name
       --timeout duration                         build process timeout
 ```

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -18,19 +18,17 @@ shp buildrun create <name> [flags]
 ### Options
 
 ```
-      --buildref-apiversion string               API version of build resource to reference
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
       --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
-      --sa-generate                              generate a Kubernetes service-account for the build
       --sa-name string                           Kubernetes service-account name
       --timeout duration                         build process timeout
 ```

--- a/pkg/shp/cmd/build/delete.go
+++ b/pkg/shp/cmd/build/delete.go
@@ -3,7 +3,7 @@ package build
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,20 +58,20 @@ func (c *DeleteCommand) Run(params *params.Params, io *genericclioptions.IOStrea
 	if err != nil {
 		return err
 	}
-	if err := clientset.ShipwrightV1alpha1().Builds(params.Namespace()).Delete(c.Cmd().Context(), c.name, v1.DeleteOptions{}); err != nil {
+	if err := clientset.ShipwrightV1beta1().Builds(params.Namespace()).Delete(c.Cmd().Context(), c.name, v1.DeleteOptions{}); err != nil {
 		return err
 	}
 
 	if c.deleteRuns {
-		var brList *buildv1alpha1.BuildRunList
-		if brList, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).List(c.cmd.Context(), v1.ListOptions{
-			LabelSelector: fmt.Sprintf("%v/name=%v", buildv1alpha1.BuildDomain, c.name),
+		var brList *buildv1beta1.BuildRunList
+		if brList, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).List(c.cmd.Context(), v1.ListOptions{
+			LabelSelector: fmt.Sprintf("%v/name=%v", buildv1beta1.BuildDomain, c.name),
 		}); err != nil {
 			return err
 		}
 
 		for _, buildrun := range brList.Items {
-			if err := clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), buildrun.Name, v1.DeleteOptions{}); err != nil {
+			if err := clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), buildrun.Name, v1.DeleteOptions{}); err != nil {
 				fmt.Fprintf(io.ErrOut, "Error deleting BuildRun %q: %v\n", buildrun.Name, err)
 			}
 		}

--- a/pkg/shp/cmd/build/list.go
+++ b/pkg/shp/cmd/build/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 	"github.com/spf13/cobra"
@@ -59,7 +59,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 	columnNames := "NAME\tOUTPUT\tSTATUS"
 	columnTemplate := "%s\t%s\t%s\n"
 
-	var buildList *buildv1alpha1.BuildList
+	var buildList *buildv1beta1.BuildList
 	clientset, err := params.ShipwrightClientSet()
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 		return err
 	}
 
-	if buildList, err = clientset.ShipwrightV1alpha1().Builds(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
+	if buildList, err = clientset.ShipwrightV1beta1().Builds(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
 		return err
 	}
 	if len(buildList.Items) == 0 {

--- a/pkg/shp/cmd/build/run.go
+++ b/pkg/shp/cmd/build/run.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/follower"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/flags"
@@ -24,8 +24,8 @@ type RunCommand struct {
 
 	buildName     string
 	namespace     string
-	buildRunSpec  *buildv1alpha1.BuildRunSpec // stores command-line flags
-	follow        bool                        // flag to tail pod logs
+	buildRunSpec  *buildv1beta1.BuildRunSpec // stores command-line flags
+	follow        bool                       // flag to tail pod logs
 	follower      *follower.Follower
 	followerReady chan bool
 }
@@ -87,7 +87,7 @@ func (r *RunCommand) FollowerReady() bool {
 // Run creates a BuildRun resource based on Build's name informed on arguments.
 func (r *RunCommand) Run(params *params.Params, ioStreams *genericclioptions.IOStreams) error {
 	// resource using GenerateName, which will provide a unique instance
-	br := &buildv1alpha1.BuildRun{
+	br := &buildv1beta1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", r.buildName),
 		},
@@ -100,7 +100,7 @@ func (r *RunCommand) Run(params *params.Params, ioStreams *genericclioptions.IOS
 	if err != nil {
 		return err
 	}
-	br, err = clientset.ShipwrightV1alpha1().BuildRuns(r.namespace).Create(ctx, br, metav1.CreateOptions{})
+	br, err = clientset.ShipwrightV1beta1().BuildRuns(r.namespace).Create(ctx, br, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	shpfake "github.com/shipwright-io/build/pkg/client/clientset/versioned/fake"
 	"github.com/shipwright-io/cli/pkg/shp/flags"
 	"github.com/shipwright-io/cli/pkg/shp/params"
@@ -98,8 +98,8 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
 				Labels: map[string]string{
-					buildv1alpha1.LabelBuild:    name,
-					buildv1alpha1.LabelBuildRun: name,
+					buildv1beta1.LabelBuild:    name,
+					buildv1beta1.LabelBuildRun: name,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -108,7 +108,7 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 				}},
 			},
 		}
-		br := &buildv1alpha1.BuildRun{
+		br := &buildv1beta1.BuildRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
@@ -153,26 +153,26 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 
 		switch {
 		case test.cancelled:
-			br.Spec.State = buildv1alpha1.BuildRunRequestedStatePtr(buildv1alpha1.BuildRunStateCancel)
-			br.Status.Conditions = []buildv1alpha1.Condition{
+			br.Spec.State = buildv1beta1.BuildRunRequestedStatePtr(buildv1beta1.BuildRunStateCancel)
+			br.Status.Conditions = []buildv1beta1.Condition{
 				{
-					Type:   buildv1alpha1.Succeeded,
+					Type:   buildv1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.brDeleted:
 			br.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []buildv1alpha1.Condition{
+			br.Status.Conditions = []buildv1beta1.Condition{
 				{
-					Type:   buildv1alpha1.Succeeded,
+					Type:   buildv1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.podDeleted:
 			pod.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []buildv1alpha1.Condition{
+			br.Status.Conditions = []buildv1beta1.Condition{
 				{
-					Type:   buildv1alpha1.Succeeded,
+					Type:   buildv1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}

--- a/pkg/shp/cmd/buildrun/cancel.go
+++ b/pkg/shp/cmd/buildrun/cancel.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 )
@@ -56,8 +56,8 @@ func (c *CancelCommand) Run(params *params.Params, ioStreams *genericclioptions.
 		return err
 	}
 
-	var br *buildv1alpha1.BuildRun
-	if br, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Get(c.cmd.Context(), c.name, metav1.GetOptions{}); err != nil {
+	var br *buildv1beta1.BuildRun
+	if br, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Get(c.cmd.Context(), c.name, metav1.GetOptions{}); err != nil {
 		return fmt.Errorf("failed to retrieve BuildRun %s: %s", c.name, err.Error())
 	}
 	if br.IsDone() {
@@ -72,13 +72,13 @@ func (c *CancelCommand) Run(params *params.Params, ioStreams *genericclioptions.
 	payload := []patchStringValue{{
 		Op:    "replace",
 		Path:  "/spec/state",
-		Value: buildv1alpha1.BuildRunStateCancel,
+		Value: buildv1beta1.BuildRunStateCancel,
 	}}
 	var data []byte
 	if data, err = json.Marshal(payload); err != nil {
 		return err
 	}
-	if _, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Patch(c.Cmd().Context(), c.name, types.JSONPatchType, data, metav1.PatchOptions{}); err != nil {
+	if _, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Patch(c.Cmd().Context(), c.name, types.JSONPatchType, data, metav1.PatchOptions{}); err != nil {
 		return err
 	}
 

--- a/pkg/shp/cmd/buildrun/cancel_test.go
+++ b/pkg/shp/cmd/buildrun/cancel_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/build/pkg/client/clientset/versioned/fake"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 )
 
 func TestCancelBuildRun(t *testing.T) {
 	tests := map[string]struct {
-		br              *v1alpha1.BuildRun
+		br              *v1beta1.BuildRun
 		expectCancelSet bool
 		expectErr       bool
 	}{
@@ -26,15 +26,15 @@ func TestCancelBuildRun(t *testing.T) {
 			expectErr: true,
 		},
 		"completed": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "completed",
 					Namespace: metav1.NamespaceDefault,
 				},
-				Status: v1alpha1.BuildRunStatus{
-					Conditions: v1alpha1.Conditions{
+				Status: v1beta1.BuildRunStatus{
+					Conditions: v1beta1.Conditions{
 						{
-							Type:   v1alpha1.Succeeded,
+							Type:   v1beta1.Succeeded,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -42,15 +42,15 @@ func TestCancelBuildRun(t *testing.T) {
 			expectErr: true,
 		},
 		"failed": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "failed",
 					Namespace: metav1.NamespaceDefault,
 				},
-				Status: v1alpha1.BuildRunStatus{
-					Conditions: v1alpha1.Conditions{
+				Status: v1beta1.BuildRunStatus{
+					Conditions: v1beta1.Conditions{
 						{
-							Type:   v1alpha1.Succeeded,
+							Type:   v1beta1.Succeeded,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -58,7 +58,7 @@ func TestCancelBuildRun(t *testing.T) {
 			expectErr: true,
 		},
 		"condition-missing": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "failed",
 					Namespace: metav1.NamespaceDefault,
@@ -67,15 +67,15 @@ func TestCancelBuildRun(t *testing.T) {
 			expectCancelSet: true,
 		},
 		"in-progress": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "failed",
 					Namespace: metav1.NamespaceDefault,
 				},
-				Status: v1alpha1.BuildRunStatus{
-					Conditions: v1alpha1.Conditions{
+				Status: v1beta1.BuildRunStatus{
+					Conditions: v1beta1.Conditions{
 						{
-							Type:   v1alpha1.Succeeded,
+							Type:   v1beta1.Succeeded,
 							Status: corev1.ConditionUnknown,
 						},
 					},
@@ -112,7 +112,7 @@ func TestCancelBuildRun(t *testing.T) {
 			continue
 		}
 
-		buildRun, _ := clientset.ShipwrightV1alpha1().BuildRuns(param.Namespace()).Get(context.Background(), test.br.Name, metav1.GetOptions{})
+		buildRun, _ := clientset.ShipwrightV1beta1().BuildRuns(param.Namespace()).Get(context.Background(), test.br.Name, metav1.GetOptions{})
 
 		if test.expectCancelSet && !buildRun.IsCanceled() {
 			t.Errorf("%s: cancel not set", testName)

--- a/pkg/shp/cmd/buildrun/create.go
+++ b/pkg/shp/cmd/buildrun/create.go
@@ -3,7 +3,7 @@ package buildrun
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,8 +18,8 @@ import (
 type CreateCommand struct {
 	cmd *cobra.Command // cobra command instance
 
-	name         string                      // buildrun name
-	buildRunSpec *buildv1alpha1.BuildRunSpec // stores command-line flags
+	name         string                     // buildrun name
+	buildRunSpec *buildv1beta1.BuildRunSpec // stores command-line flags
 }
 
 const buildRunCreateLongDesc = `
@@ -55,7 +55,7 @@ func (c *CreateCommand) Validate() error {
 
 // Run executes the creation of BuildRun object.
 func (c *CreateCommand) Run(params *params.Params, ioStreams *genericclioptions.IOStreams) error {
-	br := &buildv1alpha1.BuildRun{
+	br := &buildv1beta1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.name,
 		},
@@ -68,10 +68,12 @@ func (c *CreateCommand) Run(params *params.Params, ioStreams *genericclioptions.
 	if err != nil {
 		return err
 	}
-	if _, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Create(c.cmd.Context(), br, metav1.CreateOptions{}); err != nil {
+	if _, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Create(c.cmd.Context(), br, metav1.CreateOptions{}); err != nil {
 		return err
 	}
-	fmt.Fprintf(ioStreams.Out, "BuildRun created %q for Build %q\n", c.name, br.Spec.BuildRef.Name)
+
+	// Cli doesn't allow standalone buildruns, so it will always refer an existing build.
+	fmt.Fprintf(ioStreams.Out, "BuildRun created %q for Build %q\n", c.name, *br.Spec.Build.Name)
 	return nil
 }
 

--- a/pkg/shp/cmd/buildrun/delete.go
+++ b/pkg/shp/cmd/buildrun/delete.go
@@ -53,7 +53,7 @@ func (c *DeleteCommand) Run(params *params.Params, ioStreams *genericclioptions.
 		return err
 	}
 
-	if err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), c.name, metav1.DeleteOptions{}); err != nil {
+	if err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), c.name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/pkg/shp/cmd/buildrun/list.go
+++ b/pkg/shp/cmd/buildrun/list.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
@@ -81,8 +81,8 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 		return err
 	}
 
-	var brs *buildv1alpha1.BuildRunList
-	if brs, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
+	var brs *buildv1beta1.BuildRunList
+	if brs, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
 		return err
 	}
 	if len(brs.Items) == 0 {
@@ -98,7 +98,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 		name := br.Name
 		status := string(metav1.ConditionUnknown)
 		for _, condition := range br.Status.Conditions {
-			if condition.Type == buildv1alpha1.Succeeded {
+			if condition.Type == buildv1beta1.Succeeded {
 				status = condition.Reason
 				break
 			}

--- a/pkg/shp/cmd/buildrun/logs.go
+++ b/pkg/shp/cmd/buildrun/logs.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
 
 	"github.com/shipwright-io/cli/pkg/shp/cmd/follower"
@@ -78,7 +78,7 @@ func (c *LogsCommand) Run(params *params.Params, ioStreams *genericclioptions.IO
 	}
 
 	lo := v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v=%v", buildv1alpha1.LabelBuildRun, c.name),
+		LabelSelector: fmt.Sprintf("%v=%v", buildv1beta1.LabelBuildRun, c.name),
 	}
 
 	// first see if pod is already done; if so, even if we have follow == true, just do the normal path;

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -10,7 +10,7 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	fakekubetesting "k8s.io/client-go/testing"
 
-	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +27,7 @@ func TestStreamBuildLogs(t *testing.T) {
 	pod.Name = name
 	pod.Namespace = metav1.NamespaceDefault
 	pod.Labels = map[string]string{
-		v1alpha1.LabelBuildRun: name,
+		v1beta1.LabelBuildRun: name,
 	}
 	pod.Spec.Containers = []corev1.Container{
 		{
@@ -132,8 +132,8 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
 				Labels: map[string]string{
-					v1alpha1.LabelBuild:    name,
-					v1alpha1.LabelBuildRun: name,
+					v1beta1.LabelBuild:    name,
+					v1beta1.LabelBuildRun: name,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -142,7 +142,7 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 				}},
 			},
 		}
-		br := &v1alpha1.BuildRun{
+		br := &v1beta1.BuildRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
@@ -186,26 +186,26 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 
 		switch {
 		case test.cancelled:
-			br.Spec.State = v1alpha1.BuildRunRequestedStatePtr(v1alpha1.BuildRunStateCancel)
-			br.Status.Conditions = []v1alpha1.Condition{
+			br.Spec.State = v1beta1.BuildRunRequestedStatePtr(v1beta1.BuildRunStateCancel)
+			br.Status.Conditions = []v1beta1.Condition{
 				{
-					Type:   v1alpha1.Succeeded,
+					Type:   v1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.brDeleted:
 			br.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []v1alpha1.Condition{
+			br.Status.Conditions = []v1beta1.Condition{
 				{
-					Type:   v1alpha1.Succeeded,
+					Type:   v1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.podDeleted:
 			pod.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []v1alpha1.Condition{
+			br.Status.Conditions = []v1beta1.Condition{
 				{
-					Type:   v1alpha1.Succeeded,
+					Type:   v1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}

--- a/pkg/shp/flags/buildrun.go
+++ b/pkg/shp/flags/buildrun.go
@@ -1,7 +1,7 @@
 package flags
 
 import (
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/pflag"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,30 +10,27 @@ import (
 )
 
 // BuildRunSpecFromFlags creates a BuildRun spec from command-line flags.
-func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildRunSpec {
-	spec := &buildv1alpha1.BuildRunSpec{
-		BuildRef: &buildv1alpha1.BuildRef{
-			APIVersion: ptr.To(""),
+func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1beta1.BuildRunSpec {
+	spec := &buildv1beta1.BuildRunSpec{
+		Build: buildv1beta1.ReferencedBuild{
+			Name: ptr.To(""),
 		},
-		ServiceAccount: &buildv1alpha1.ServiceAccount{
-			Name:     ptr.To(""),
-			Generate: ptr.To(false),
-		},
-		Timeout: &metav1.Duration{},
-		Output: &buildv1alpha1.Image{
-			Credentials: &corev1.LocalObjectReference{},
+		ServiceAccount: ptr.To(""),
+		Timeout:        &metav1.Duration{},
+		Output: &buildv1beta1.Image{
+			PushSecret:  ptr.To(""),
 			Insecure:    ptr.To(false),
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
 		Env: []corev1.EnvVar{},
-		Retention: &buildv1alpha1.BuildRunRetention{
+		Retention: &buildv1beta1.BuildRunRetention{
 			TTLAfterFailed:    &metav1.Duration{},
 			TTLAfterSucceeded: &metav1.Duration{},
 		},
 	}
 
-	buildRefFlags(flags, spec.BuildRef)
+	buildRefFlags(flags, &spec.Build)
 	serviceAccountFlags(flags, spec.ServiceAccount)
 	timeoutFlags(flags, spec.Timeout)
 	imageFlags(flags, "output", spec.Output)
@@ -47,33 +44,24 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildRunSpec {
 }
 
 // SanitizeBuildRunSpec checks for empty inner data structures and replaces them with nil.
-func SanitizeBuildRunSpec(br *buildv1alpha1.BuildRunSpec) {
+func SanitizeBuildRunSpec(br *buildv1beta1.BuildRunSpec) {
 	if br == nil {
 		return
 	}
-	if br.BuildRef != nil {
-		if br.BuildRef.APIVersion != nil && *br.BuildRef.APIVersion == "" {
-			br.BuildRef.APIVersion = nil
-		}
-
-		if br.BuildRef.Name == "" && br.BuildRef.APIVersion == nil {
-			br.BuildRef = nil
-		}
+	if br.Build.Name != nil && *br.Build.Name == "" {
+		br.Build.Name = nil
 	}
-	if br.ServiceAccount != nil {
-		if (br.ServiceAccount.Name == nil || *br.ServiceAccount.Name == "") &&
-			(br.ServiceAccount.Generate == nil || !*br.ServiceAccount.Generate) {
-			br.ServiceAccount = nil
-		}
+	if br.ServiceAccount != nil && *br.ServiceAccount == "" {
+		br.ServiceAccount = nil
 	}
 	if br.Output != nil {
-		if br.Output.Credentials != nil && br.Output.Credentials.Name == "" {
-			br.Output.Credentials = nil
+		if br.Output.PushSecret != nil && *br.Output.PushSecret == "" {
+			br.Output.PushSecret = nil
 		}
 		if br.Output.Insecure != nil && !*br.Output.Insecure {
 			br.Output.Insecure = nil
 		}
-		if br.Output.Image == "" && br.Output.Credentials == nil {
+		if br.Output.Image == "" && br.Output.PushSecret == nil {
 			br.Output = nil
 		}
 	}

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -1,14 +1,12 @@
 package flags
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
 	o "github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -17,26 +15,22 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 	g := o.NewWithT(t)
 
 	str := "something-random"
-	expected := &buildv1alpha1.BuildRunSpec{
-		BuildRef: &buildv1alpha1.BuildRef{
-			Name:       str,
-			APIVersion: ptr.To(""),
+	expected := &buildv1beta1.BuildRunSpec{
+		Build: buildv1beta1.ReferencedBuild{
+			Name: &str,
 		},
-		ServiceAccount: &buildv1alpha1.ServiceAccount{
-			Name:     &str,
-			Generate: ptr.To(false),
-		},
+		ServiceAccount: &str,
 		Timeout: &metav1.Duration{
 			Duration: 1 * time.Second,
 		},
-		Output: &buildv1alpha1.Image{
-			Credentials: &corev1.LocalObjectReference{Name: "name"},
+		Output: &buildv1beta1.Image{
+			PushSecret:  ptr.To("name"),
 			Image:       str,
 			Insecure:    ptr.To(false),
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
-		Retention: &buildv1alpha1.BuildRunRetention{
+		Retention: &buildv1beta1.BuildRunRetention{
 			TTLAfterFailed: &metav1.Duration{
 				Duration: 48 * time.Hour,
 			},
@@ -51,17 +45,14 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 	spec := BuildRunSpecFromFlags(flags)
 
 	t.Run(".spec.buildRef", func(_ *testing.T) {
-		err := flags.Set(BuildrefNameFlag, expected.BuildRef.Name)
+		err := flags.Set(BuildrefNameFlag, *expected.Build.Name)
 		g.Expect(err).To(o.BeNil())
 
-		g.Expect(*expected.BuildRef).To(o.Equal(*spec.BuildRef), "spec.buildRef")
+		g.Expect(expected.Build).To(o.Equal(spec.Build), "spec.buildRef")
 	})
 
 	t.Run(".spec.serviceAccount", func(_ *testing.T) {
-		err := flags.Set(ServiceAccountNameFlag, *expected.ServiceAccount.Name)
-		g.Expect(err).To(o.BeNil())
-
-		err = flags.Set(ServiceAccountGenerateFlag, strconv.FormatBool(*expected.ServiceAccount.Generate))
+		err := flags.Set(ServiceAccountNameFlag, *expected.ServiceAccount)
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(*expected.ServiceAccount).To(o.Equal(*spec.ServiceAccount), "spec.serviceAccount")
@@ -78,7 +69,7 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 		err := flags.Set(OutputImageFlag, expected.Output.Image)
 		g.Expect(err).To(o.BeNil())
 
-		err = flags.Set(OutputCredentialsSecretFlag, expected.Output.Credentials.Name)
+		err = flags.Set(OutputCredentialsSecretFlag, *expected.Output.PushSecret)
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(*expected.Output).To(o.Equal(*spec.Output), "spec.output")
@@ -103,46 +94,46 @@ func TestSanitizeBuildRunSpec(t *testing.T) {
 	g := o.NewWithT(t)
 
 	name := "name"
-	completeBuildRunSpec := buildv1alpha1.BuildRunSpec{
-		ServiceAccount: &buildv1alpha1.ServiceAccount{Name: &name},
-		Output: &buildv1alpha1.Image{
-			Credentials: &corev1.LocalObjectReference{Name: "name"},
-			Image:       "image",
+	completeBuildRunSpec := buildv1beta1.BuildRunSpec{
+		ServiceAccount: &name,
+		Output: &buildv1beta1.Image{
+			PushSecret: ptr.To("name"),
+			Image:      "image",
 		},
 	}
 
 	testCases := []struct {
 		name string
-		in   buildv1alpha1.BuildRunSpec
-		out  buildv1alpha1.BuildRunSpec
+		in   buildv1beta1.BuildRunSpec
+		out  buildv1beta1.BuildRunSpec
 	}{{
 		name: "all empty should stay empty",
-		in:   buildv1alpha1.BuildRunSpec{},
-		out:  buildv1alpha1.BuildRunSpec{},
+		in:   buildv1beta1.BuildRunSpec{},
+		out:  buildv1beta1.BuildRunSpec{},
 	}, {
 		name: "should clean-up service-account",
-		in:   buildv1alpha1.BuildRunSpec{ServiceAccount: &buildv1alpha1.ServiceAccount{}},
-		out:  buildv1alpha1.BuildRunSpec{},
+		in:   buildv1beta1.BuildRunSpec{ServiceAccount: ptr.To("")},
+		out:  buildv1beta1.BuildRunSpec{},
 	}, {
 		name: "should clean-up output",
-		in:   buildv1alpha1.BuildRunSpec{Output: &buildv1alpha1.Image{}},
-		out:  buildv1alpha1.BuildRunSpec{},
+		in:   buildv1beta1.BuildRunSpec{Output: &buildv1beta1.Image{}},
+		out:  buildv1beta1.BuildRunSpec{},
 	}, {
 		name: "should not clean-up complete objects",
 		in:   completeBuildRunSpec,
 		out:  completeBuildRunSpec,
 	}, {
 		name: "should clean-up 0s duration",
-		in: buildv1alpha1.BuildRunSpec{Timeout: &metav1.Duration{
+		in: buildv1beta1.BuildRunSpec{Timeout: &metav1.Duration{
 			Duration: time.Duration(0),
 		}},
-		out: buildv1alpha1.BuildRunSpec{Timeout: nil},
+		out: buildv1beta1.BuildRunSpec{Timeout: nil},
 	}, {
 		name: "should clean-up an empty retention",
-		in: buildv1alpha1.BuildRunSpec{
-			Retention: &buildv1alpha1.BuildRunRetention{},
+		in: buildv1beta1.BuildRunSpec{
+			Retention: &buildv1beta1.BuildRunRetention{},
 		},
-		out: buildv1alpha1.BuildRunSpec{},
+		out: buildv1beta1.BuildRunSpec{},
 	}}
 
 	for _, tt := range testCases {

--- a/pkg/shp/flags/core_envvar_value_test.go
+++ b/pkg/shp/flags/core_envvar_value_test.go
@@ -3,7 +3,7 @@ package flags
 import (
 	"testing"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 
 	o "github.com/onsi/gomega"
@@ -12,7 +12,7 @@ import (
 func TestCoreEnvVarSliceValue(t *testing.T) {
 	g := o.NewWithT(t)
 
-	spec := &buildv1alpha1.BuildSpec{Env: []corev1.EnvVar{}}
+	spec := &buildv1beta1.BuildSpec{Env: []corev1.EnvVar{}}
 	c := NewCoreEnvVarArrayValue(&spec.Env)
 
 	// expect error when key-value is not split by equal sign

--- a/pkg/shp/flags/map_value_test.go
+++ b/pkg/shp/flags/map_value_test.go
@@ -3,7 +3,7 @@ package flags
 import (
 	"testing"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	o "github.com/onsi/gomega"
 )
@@ -11,7 +11,7 @@ import (
 func TestNewMapValue(t *testing.T) {
 	g := o.NewWithT(t)
 
-	spec := &buildv1alpha1.BuildSpec{Output: buildv1alpha1.Image{
+	spec := &buildv1beta1.BuildSpec{Output: buildv1beta1.Image{
 		Labels: map[string]string{},
 	}}
 	c := NewMapValue(spec.Output.Labels)

--- a/pkg/shp/flags/param_value.go
+++ b/pkg/shp/flags/param_value.go
@@ -3,13 +3,13 @@ package flags
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 // ParamArrayValue implements pflag.Value interface, in order to store ParamValue key-value
 // pairs used on Shipwright's BuildSpec.
 type ParamArrayValue struct {
-	params *[]buildv1alpha1.ParamValue // pointer to the slice of ParamValue
+	params *[]buildv1beta1.ParamValue // pointer to the slice of ParamValue
 }
 
 // String prints out the string representation of the slice of EnvVar objects.
@@ -33,7 +33,7 @@ func (p *ParamArrayValue) Set(value string) error {
 			return fmt.Errorf("environment variable '%s' is already set", k)
 		}
 	}
-	*p.params = append(*p.params, buildv1alpha1.ParamValue{Name: k, SingleValue: &buildv1alpha1.SingleValue{Value: &v}})
+	*p.params = append(*p.params, buildv1beta1.ParamValue{Name: k, SingleValue: &buildv1beta1.SingleValue{Value: &v}})
 	return nil
 }
 
@@ -45,6 +45,6 @@ func (p *ParamArrayValue) Type() string {
 }
 
 // NewCoreEnvVarArrayValue instantiate a ParamValSliceValue sharing the EnvVar pointer.
-func NewParamArrayValue(params *[]buildv1alpha1.ParamValue) *ParamArrayValue {
+func NewParamArrayValue(params *[]buildv1beta1.ParamValue) *ParamArrayValue {
 	return &ParamArrayValue{params: params}
 }

--- a/pkg/shp/flags/param_value_test.go
+++ b/pkg/shp/flags/param_value_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 func TestNewParamArrayValue(t *testing.T) {
@@ -42,7 +42,7 @@ func TestNewParamArrayValue(t *testing.T) {
 	}
 	for tName, tCase := range testCases {
 		t.Run(tName, func(_ *testing.T) {
-			buildSpec := buildv1alpha1.BuildSpec{}
+			buildSpec := buildv1beta1.BuildSpec{}
 			buildParamVal := NewParamArrayValue(&buildSpec.ParamValues)
 
 			err := buildParamVal.Set(tCase.paramPassed)

--- a/pkg/shp/flags/prune_option_value.go
+++ b/pkg/shp/flags/prune_option_value.go
@@ -3,28 +3,28 @@ package flags
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 // pruneOptionFlag serves as an adapter to make the Build spec source bundle
 // container prune option to be used as a command-line flag (pflag.Value).
 type pruneOptionFlag struct {
-	ref *buildv1alpha1.PruneOption
+	ref *buildv1beta1.PruneOption
 }
 
 // Set translates the provided input string into one of the supported prune
 // options, or fails with an error in cases of an unsupported value
 func (p pruneOptionFlag) Set(val string) error {
-	var pruneOption = buildv1alpha1.PruneOption(val)
+	var pruneOption = buildv1beta1.PruneOption(val)
 	switch pruneOption {
-	case buildv1alpha1.PruneNever, buildv1alpha1.PruneAfterPull:
+	case buildv1beta1.PruneNever, buildv1beta1.PruneAfterPull:
 		*p.ref = pruneOption
 		return nil
 
 	default:
 		return fmt.Errorf("supported values are %s, or %s",
-			buildv1alpha1.PruneNever,
-			buildv1alpha1.PruneAfterPull,
+			buildv1beta1.PruneNever,
+			buildv1beta1.PruneAfterPull,
 		)
 	}
 }
@@ -33,7 +33,7 @@ func (p pruneOptionFlag) Set(val string) error {
 // spec source container bundle prune default of `Never` in case it is not set
 func (p pruneOptionFlag) String() string {
 	if p.ref == nil {
-		return string(buildv1alpha1.PruneNever)
+		return string(buildv1beta1.PruneNever)
 	}
 
 	return string(*p.ref)

--- a/pkg/shp/flags/prune_option_value_test.go
+++ b/pkg/shp/flags/prune_option_value_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	o "github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 func TestSourcePruneOption(t *testing.T) {
@@ -12,16 +12,16 @@ func TestSourcePruneOption(t *testing.T) {
 
 	// Check for type and defaults
 	g.Expect(pruneOptionFlag{}.Type()).To(o.Equal("pruneOption"))
-	g.Expect(pruneOptionFlag{}.String()).To(o.Equal(string(buildv1alpha1.PruneNever)))
+	g.Expect(pruneOptionFlag{}.String()).To(o.Equal(string(buildv1beta1.PruneNever)))
 
-	var obj buildv1alpha1.PruneOption
+	var obj buildv1beta1.PruneOption
 	v := pruneOptionFlag{ref: &obj}
 
 	// Check the supported values
-	g.Expect(v.Set(string(buildv1alpha1.PruneNever))).Should(o.Succeed())
-	g.Expect(v.String()).To(o.Equal(string(buildv1alpha1.PruneNever)))
-	g.Expect(v.Set(string(buildv1alpha1.PruneAfterPull))).Should(o.Succeed())
-	g.Expect(v.String()).To(o.Equal(string(buildv1alpha1.PruneAfterPull)))
+	g.Expect(v.Set(string(buildv1beta1.PruneNever))).Should(o.Succeed())
+	g.Expect(v.String()).To(o.Equal(string(buildv1beta1.PruneNever)))
+	g.Expect(v.Set(string(buildv1beta1.PruneAfterPull))).Should(o.Succeed())
+	g.Expect(v.String()).To(o.Equal(string(buildv1beta1.PruneAfterPull)))
 
 	// Check that invalid values fail with the flag
 	g.Expect(v.Set("invalid")).ToNot(o.Succeed())

--- a/pkg/shp/flags/strategy_kind_value.go
+++ b/pkg/shp/flags/strategy_kind_value.go
@@ -3,13 +3,13 @@ package flags
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 // StrategyKindValue implements pflag.Value interface, to represent Shipwright's BuildStrategyKind as
 // a string command-line in an cobra.Command instance.
 type StrategyKindValue struct {
-	kindPtr *buildv1alpha1.BuildStrategyKind
+	kindPtr *buildv1beta1.BuildStrategyKind
 }
 
 // String shows the value as string.
@@ -22,9 +22,9 @@ func (s *StrategyKindValue) String() string {
 
 // Set set the informed string as BuildStrategyKind by casting.
 func (s *StrategyKindValue) Set(value string) error {
-	kind := buildv1alpha1.BuildStrategyKind(value)
-	if kind != buildv1alpha1.NamespacedBuildStrategyKind &&
-		kind != buildv1alpha1.ClusterBuildStrategyKind {
+	kind := buildv1beta1.BuildStrategyKind(value)
+	if kind != buildv1beta1.NamespacedBuildStrategyKind &&
+		kind != buildv1beta1.ClusterBuildStrategyKind {
 		return fmt.Errorf("'%s' is an invalid BuildStrategyKind", value)
 	}
 	*s.kindPtr = kind
@@ -37,6 +37,6 @@ func (s *StrategyKindValue) Type() string {
 }
 
 // NewStrategyKindValue creates a new instance of StrategyKindValue sharing an existing reference.
-func NewStrategyKindValue(kindPtr *buildv1alpha1.BuildStrategyKind) *StrategyKindValue {
+func NewStrategyKindValue(kindPtr *buildv1beta1.BuildStrategyKind) *StrategyKindValue {
 	return &StrategyKindValue{kindPtr: kindPtr}
 }

--- a/pkg/shp/flags/strategy_kind_value_test.go
+++ b/pkg/shp/flags/strategy_kind_value_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	o "github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 func TestStrategyKindValue(t *testing.T) {
 	g := o.NewWithT(t)
 
-	buildStrategyKind := buildv1alpha1.ClusterBuildStrategyKind
+	buildStrategyKind := buildv1beta1.ClusterBuildStrategyKind
 	v := NewStrategyKindValue(&buildStrategyKind)
 
-	expected := buildv1alpha1.NamespacedBuildStrategyKind
+	expected := buildv1beta1.NamespacedBuildStrategyKind
 
 	err := v.Set(string(expected))
 	g.Expect(err).To(o.BeNil())

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -51,7 +51,7 @@ teardown() {
 	buildrun_name=$(random_name)
 
 	# ensure that shp build create does not give an error when a build_name is specified
-	run shp build create ${build_name} --source-url=url --output-image=image
+	run shp build create ${build_name} --source-git-url=url --output-image=image
 	assert_success
 
 	# ensure that shp buildrun create does not give an error when a buildrun_name is specified
@@ -63,14 +63,14 @@ teardown() {
 	# ensure that shp command doesn't log the api calls by default
 	run shp build list
 	assert_success
-	refute_line --regexp "GET .*/apis/shipwright.io/v1alpha1/namespaces/"
+	refute_line --regexp "GET .*/apis/shipwright.io/v1beta1/namespaces/"
 	refute_line --partial "Response Headers"
 	refute_line --partial "Response Body"
 
 	# ensure that shp command supports -v loglevel flag.
 	run shp -v=10 build list
 	assert_success
-	assert_line --regexp "GET .*/apis/shipwright.io/v1alpha1/namespaces/"
+	assert_line --regexp "GET .*/apis/shipwright.io/v1beta1/namespaces/"
 	assert_line --partial "Response Headers"
 	assert_line --partial "Response Body"
 }

--- a/test/e2e/envvars.bats
+++ b/test/e2e/envvars.bats
@@ -19,7 +19,7 @@ teardown() {
 	buildrun_name=$(random_name)
 
 	# create a Build with two environment variables
-	run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image --env=VAR_1=build-value-1 --env=VAR_2=build-value-2
+	run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-image --env=VAR_1=build-value-1 --env=VAR_2=build-value-2
 	assert_success
 
 	# ensure that the build was successfully created

--- a/test/e2e/log-follow--follow.bats
+++ b/test/e2e/log-follow--follow.bats
@@ -21,7 +21,7 @@ teardown() {
 
     # creating a golang based build
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image}
     assert_success

--- a/test/e2e/log-follow-F.bats
+++ b/test/e2e/log-follow-F.bats
@@ -21,7 +21,7 @@ teardown() {
 
     # create a Build with two environment variables
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image}
     assert_success

--- a/test/e2e/output-image-labels-annotations.bats
+++ b/test/e2e/output-image-labels-annotations.bats
@@ -19,7 +19,7 @@ teardown() {
 	buildrun_name=$(random_name)
 
 	# create a Build with a label and an annotation
-	run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image --output-image-label=foo=bar --output-image-annotation=created-by=shipwright
+	run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-image --output-image-label=foo=bar --output-image-annotation=created-by=shipwright
 	assert_success
 
 	# ensure that the build was successfully created

--- a/test/e2e/run-follow.bats
+++ b/test/e2e/run-follow.bats
@@ -21,7 +21,7 @@ teardown() {
 
     # create a Build
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image}
     assert_success
@@ -53,7 +53,7 @@ teardown() {
 
     # create a Build which will fail
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image} \
         --strategy-name buildkit

--- a/test/e2e/upload.bats
+++ b/test/e2e/upload.bats
@@ -39,7 +39,7 @@ function assert_shp_upload_follow_output() {
 	# change directory (cd) during the build process, so if the directory is not uploaded properly
 	# the actual build will fail
 	run shp build create ${build_name} \
-		--source-url="${source_url}" \
+		--source-git-url="${source_url}" \
 		--source-context-dir="source-build" \
 		--output-image="${output_image}"
 	assert_success
@@ -82,8 +82,8 @@ function assert_shp_upload_follow_output() {
 
 	# Verify that invalid prune options are not accepted
 	run shp build create ${build_name} \
-		--source-bundle-image="$(get_output_image source-bundle):latest" \
-		--source-bundle-prune=Magic
+		--source-oci-artifact-image="$(get_output_image source-bundle):latest" \
+		--source-oci-artifact-prune=Magic
 	assert_failure
 	assert_output --partial 'invalid argument'
 
@@ -95,8 +95,8 @@ function assert_shp_upload_follow_output() {
 	# from the local shp client.
 	#
 	run shp build create ${build_name} \
-		--source-bundle-image="$(get_output_image source-bundle):latest" \
-		--source-bundle-prune=AfterPull \
+		--source-oci-artifact-image="$(get_output_image source-bundle):latest" \
+		--source-oci-artifact-prune=AfterPull \
 		--source-context-dir="docker-build" \
 		--dockerfile=Dockerfile \
 		--strategy-name=kaniko \

--- a/test/stub/client.go
+++ b/test/stub/client.go
@@ -3,7 +3,7 @@ package stub
 import (
 	"log"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -13,7 +13,7 @@ import (
 // NewFakeClient creates a fake client with Shipwright's Build scheme.
 func NewFakeClient() dynamic.Interface {
 	scheme := runtime.NewScheme()
-	if err := buildv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+	if err := buildv1beta1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		log.Fatal(err)
 	}
 	return fake.NewSimpleDynamicClient(scheme)

--- a/test/stub/stub.go
+++ b/test/stub/stub.go
@@ -1,33 +1,36 @@
 package stub
 
 import (
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BuildRunEmpty simple empty BuildRun instance.
-func BuildRunEmpty() buildv1alpha1.BuildRun {
-	return buildv1alpha1.BuildRun{}
+func BuildRunEmpty() buildv1beta1.BuildRun {
+	return buildv1beta1.BuildRun{}
 }
 
 // TestBuild returns instance of Build for testing purposes
-func TestBuild(name, image, source string) *buildv1alpha1.Build {
-	strategyKind := buildv1alpha1.ClusterBuildStrategyKind
+func TestBuild(name, image, source string) *buildv1beta1.Build {
+	strategyKind := buildv1beta1.ClusterBuildStrategyKind
 
-	result := &buildv1alpha1.Build{
+	result := &buildv1beta1.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: buildv1alpha1.BuildSpec{
-			Strategy: buildv1alpha1.Strategy{
+		Spec: buildv1beta1.BuildSpec{
+			Strategy: buildv1beta1.Strategy{
 				Name: "buildah",
 				Kind: &strategyKind,
 			},
-			Source: buildv1alpha1.Source{
-				URL: &source,
+			Source: &buildv1beta1.Source{
+				Type: buildv1beta1.GitType,
+				Git: &buildv1beta1.Git{
+					URL: source,
+				},
 			},
-			Output: buildv1alpha1.Image{
+			Output: buildv1beta1.Image{
 				Image: image,
 			},
 		},


### PR DESCRIPTION
# Changes

Add code changes to move to v1beta1 from v1alpha1

Fixes https://github.com/shipwright-io/cli/issues/294

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The CLI now interacts with the Shipwright artifacts using the v1beta1 API
```
