### PR TITLE
Add `--node-selector` Flag for `shp build/buildrun` Commands

### DIFF
--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -19,6 +19,7 @@ shp build create <name> [flags]
 ```
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -22,6 +22,7 @@ shp build run <name> [flags]
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for run
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -32,6 +32,7 @@ shp build upload <build-name> [path/to/source|.] [flags]
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for upload
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -21,6 +21,7 @@ shp buildrun create <name> [flags]
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/pkg/shp/flags/build.go
+++ b/pkg/shp/flags/build.go
@@ -44,6 +44,7 @@ func BuildSpecFromFlags(flags *pflag.FlagSet) (*buildv1beta1.BuildSpec, *string,
 			TTLAfterFailed:    &metav1.Duration{},
 			TTLAfterSucceeded: &metav1.Duration{},
 		},
+		NodeSelector: map[string]string{},
 	}
 
 	sourceFlags(flags, spec.Source)
@@ -55,7 +56,7 @@ func BuildSpecFromFlags(flags *pflag.FlagSet) (*buildv1beta1.BuildSpec, *string,
 	imageLabelsFlags(flags, spec.Output.Labels)
 	imageAnnotationsFlags(flags, spec.Output.Annotations)
 	buildRetentionFlags(flags, spec.Retention)
-
+	buildNodeSelectorFlags(flags, spec.NodeSelector)
 	var dockerfile, builderImage string
 	dockerfileFlags(flags, &dockerfile)
 	builderImageFlag(flags, &builderImage)

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -55,6 +55,7 @@ func TestBuildSpecFromFlags(t *testing.T) {
 				Duration: 30 * time.Minute,
 			},
 		},
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
 	}
 
 	cmd := &cobra.Command{}
@@ -113,6 +114,13 @@ func TestBuildSpecFromFlags(t *testing.T) {
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(expected.Output).To(o.Equal(spec.Output), "spec.output")
+	})
+
+	t.Run(".spec.nodeSelector", func(_ *testing.T) {
+		err := flags.Set(NodeSelectorFlag, "kubernetes.io/hostname=worker-1")
+		g.Expect(err).To(o.BeNil())
+		// g.Expect(expected.NodeSelector).To(o.HaveKeyWithValue("kubernetes.io/hostname",spec.NodeSelector["kubernetes.io/hostname"]), ".spec.nodeSelector")
+		g.Expect(expected.NodeSelector).To(o.Equal(spec.NodeSelector), ".spec.nodeSelector")
 	})
 
 	t.Run(".spec.timeout", func(_ *testing.T) {

--- a/pkg/shp/flags/buildrun.go
+++ b/pkg/shp/flags/buildrun.go
@@ -28,6 +28,7 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1beta1.BuildRunSpec {
 			TTLAfterFailed:    &metav1.Duration{},
 			TTLAfterSucceeded: &metav1.Duration{},
 		},
+		NodeSelector: map[string]string{},
 	}
 
 	buildRefFlags(flags, &spec.Build)
@@ -39,7 +40,7 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1beta1.BuildRunSpec {
 	imageLabelsFlags(flags, spec.Output.Labels)
 	imageAnnotationsFlags(flags, spec.Output.Annotations)
 	buildRunRetentionFlags(flags, spec.Retention)
-
+	buildNodeSelectorFlags(flags, spec.NodeSelector)
 	return spec
 }
 

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -38,6 +38,7 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 				Duration: 30 * time.Minute,
 			},
 		},
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
 	}
 
 	cmd := &cobra.Command{}
@@ -73,6 +74,13 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(*expected.Output).To(o.Equal(*spec.Output), "spec.output")
+	})
+
+	t.Run(".spec.nodeSelector", func(_ *testing.T) {
+		err := flags.Set(NodeSelectorFlag, "kubernetes.io/hostname=worker-1")
+		g.Expect(err).To(o.BeNil())
+		// g.Expect(expected.NodeSelector).To(o.HaveKeyWithValue("kubernetes.io/hostname",spec.NodeSelector["kubernetes.io/hostname"]), ".spec.nodeSelector")
+		g.Expect(expected.NodeSelector).To(o.Equal(spec.NodeSelector), ".spec.nodeSelector")
 	})
 
 	t.Run(".spec.retention.ttlAfterFailed", func(_ *testing.T) {

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -64,6 +64,8 @@ const (
 	RetentionTTLAfterFailedFlag = "retention-ttl-after-failed"
 	// RetentionTTLAfterSucceededFlag command-line flag.
 	RetentionTTLAfterSucceededFlag = "retention-ttl-after-succeeded"
+	// NodeSelectorFlag command-line flag.
+	NodeSelectorFlag = "node-selector"
 )
 
 // sourceFlags flags for ".spec.source"
@@ -257,6 +259,11 @@ func serviceAccountFlags(flags *pflag.FlagSet, sa *string) {
 	)
 	flags.MarkDeprecated("sa-generate", fmt.Sprintf("this flag has no effect, please use --%s for service account", ServiceAccountNameFlag))
 
+}
+
+// buildNodeSelectorFlags registers flags for adding BuildSpec.NodeSelector
+func buildNodeSelectorFlags(flags *pflag.FlagSet, nodeSelectorLabels map[string]string) {
+	flags.Var(NewMapValue(nodeSelectorLabels), NodeSelectorFlag, "set of key-value pairs that correspond to labels of a node to match")
 }
 
 // envFlags registers flags for adding corev1.EnvVars.

--- a/test/e2e/node-selector.bats
+++ b/test/e2e/node-selector.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+
+source test/e2e/helpers.sh
+
+setup() {
+	load 'bats/support/load'
+	load 'bats/assert/load'
+	load 'bats/file/load'
+}
+
+teardown() {
+	run kubectl delete builds.shipwright.io --all
+	run kubectl delete buildruns.shipwright.io --all
+}
+
+@test "shp build create --node-selector single label" {
+    # generate random names for our build
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-fake-image --node-selector="kubernetes.io/hostname=node-1"
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get builds.shipwright.io/${build_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output '{"kubernetes.io/hostname":"node-1"}'
+}
+
+@test "shp build create --node-selector multiple labels" {
+    # generate random names for our build
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-fake-image --node-selector="kubernetes.io/hostname=node-1" --node-selector="kubernetes.io/os=linux" 
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get builds.shipwright.io/${build_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output --partial '"kubernetes.io/hostname":"node-1"'
+    assert_output --partial '"kubernetes.io/os":"linux"'
+}
+
+@test "shp buildrun create --node-selector single label" {
+    # generate random names for our buildrun
+	buildrun_name=$(random_name)
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp buildrun create ${buildrun_name} --buildref-name=${build_name} --node-selector="kubernetes.io/hostname=node-1"
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "BuildRun created \"${buildrun_name}\" for Build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get buildruns.shipwright.io/${buildrun_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output '{"kubernetes.io/hostname":"node-1"}'
+}
+
+@test "shp buildrun create --node-selector multiple labels" {
+    # generate random names for our buildrun
+	buildrun_name=$(random_name)
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp buildrun create ${buildrun_name} --buildref-name=${build_name} --node-selector="kubernetes.io/hostname=node-1"  --node-selector="kubernetes.io/os=linux"
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "BuildRun created \"${buildrun_name}\" for Build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get buildruns.shipwright.io/${buildrun_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output --partial '"kubernetes.io/hostname":"node-1"'
+    assert_output --partial '"kubernetes.io/os":"linux"'
+}
+
+
+@test "shp build run --node-selector set" {
+    # generate random names for our build
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-fake-image
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+    # get the build object
+	run kubectl get builds.shipwright.io/${build_name}
+	assert_success
+
+    run shp build run ${build_name} --node-selector="kubernetes.io/hostname=node-1"
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get buildruns.shipwright.io -ojsonpath='{.items[*].spec.nodeSelector}' 
+	assert_success
+    assert_output --partial '"kubernetes.io/hostname":"node-1"'
+}


### PR DESCRIPTION
# Changes

Fixes #260 

Add CLI flag `--node` to set `.spec.nodeSelector` to a `Build` or `BuildRun` 

❗ **IMPORTANT:** depends on [PR 304](https://github.com/shipwright-io/cli/pull/304)

PR's codebase is tracking [PR 304](https://github.com/shipwright-io/cli/pull/304) by @karanibm6 as `.spec.nodeSelector` is only defined on `builds.shipwright.io/v1beta1` as a consequence of the current `main` branch for CLI relying on `builds.shipwright.io/v1alpha1` (see [PR 1683](https://github.com/shipwright-io/build/pull/1683))



# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add flag --node-selector to set the `.spec.nodeSelector` for `build` and `buildrun` on create
```
