### PR TITLE
Address `golangci-lint` findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,3 +6,10 @@ linters:
     - gocritic
   disable:
     - errcheck
+
+  exclusions:
+    rules:
+    - path: \.go$
+      text: "should have a package comment"
+      linters:
+      - revive

--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -141,7 +141,9 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 		}
 
 		// set up context
-		cmd.Cmd().ExecuteC()
+		if _, err := cmd.Cmd().ExecuteC(); err != nil {
+			t.Error(err.Error())
+		}
 		pm := genericclioptions.NewConfigFlags(true)
 		if len(test.to) > 0 {
 			pm.Timeout = &tests[i].to
@@ -184,9 +186,14 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 			})
 		}
 
-		cmd.Complete(param, &ioStreams, []string{name})
+		if err := cmd.Complete(param, &ioStreams, []string{name}); err != nil {
+			t.Error(err.Error())
+		}
+
 		if len(test.to) > 0 {
-			cmd.Run(param, &ioStreams)
+			if err := cmd.Run(param, &ioStreams); err != nil {
+				t.Error(err.Error())
+			}
 			checkLog(test.name, test.logText, cmd, out, t)
 			continue
 		}
@@ -209,7 +216,9 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 		if !test.noPodYet {
 			// mimic watch events, bypassing k8s fake client watch hoopla whose plug points are not always useful;
 			pod.Status.Phase = test.phase
-			cmd.follower.OnEvent(pod)
+			if err := cmd.follower.OnEvent(pod); err != nil {
+				t.Error(err.Error())
+			}
 		} else {
 			cmd.follower.OnNoPodEventsYet(nil)
 		}

--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -216,9 +216,7 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 		if !test.noPodYet {
 			// mimic watch events, bypassing k8s fake client watch hoopla whose plug points are not always useful;
 			pod.Status.Phase = test.phase
-			if err := cmd.follower.OnEvent(pod); err != nil {
-				t.Error(err.Error())
-			}
+			_ = cmd.follower.OnEvent(pod)
 		} else {
 			cmd.follower.OnNoPodEventsYet(nil)
 		}

--- a/pkg/shp/cmd/buildrun/cancel_test.go
+++ b/pkg/shp/cmd/buildrun/cancel_test.go
@@ -96,7 +96,9 @@ func TestCancelBuildRun(t *testing.T) {
 		}
 
 		// set up context
-		cmd.Cmd().ExecuteC()
+		if _, err := cmd.Cmd().ExecuteC(); err != nil {
+			t.Error(err.Error())
+		}
 		param := params.NewParamsForTest(nil, clientset, nil, metav1.NamespaceDefault, nil, nil)
 
 		ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -239,9 +239,7 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 		if !test.noPodYet {
 			// mimic watch events, bypassing k8s fake client watch hoopla whose plug points are not always useful;
 			pod.Status.Phase = test.phase
-			if err := cmd.follower.OnEvent(pod); err != nil {
-				t.Error(err.Error())
-			}
+			_ = cmd.follower.OnEvent(pod)
 		} else {
 			cmd.follower.OnNoPodEventsYet(nil)
 		}

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -38,7 +38,9 @@ func TestStreamBuildLogs(t *testing.T) {
 	cmd := LogsCommand{cmd: &cobra.Command{}}
 	cmd.name = name
 	// set up context
-	cmd.Cmd().ExecuteC()
+	if _, err := cmd.Cmd().ExecuteC(); err != nil {
+		t.Error(err.Error())
+	}
 
 	clientset := fake.NewSimpleClientset(pod)
 	ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
@@ -175,7 +177,10 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 		}
 
 		// set up context
-		cmd.Cmd().ExecuteC()
+		if _, err := cmd.Cmd().ExecuteC(); err != nil {
+			t.Error(err.Error())
+		}
+
 		pm := genericclioptions.NewConfigFlags(true)
 		if len(test.to) > 0 {
 			pm.Timeout = &tests[i].to
@@ -211,9 +216,14 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 			}
 		}
 
-		cmd.Complete(param, &ioStreams, []string{name})
+		if err := cmd.Complete(param, &ioStreams, []string{name}); err != nil {
+			t.Error(err.Error())
+		}
+
 		if len(test.to) > 0 {
-			cmd.Run(param, &ioStreams)
+			if err := cmd.Run(param, &ioStreams); err != nil {
+				t.Error(err.Error())
+			}
 			checkLog(test.name, test.logText, cmd, out, t)
 			continue
 		}
@@ -229,7 +239,9 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 		if !test.noPodYet {
 			// mimic watch events, bypassing k8s fake client watch hoopla whose plug points are not always useful;
 			pod.Status.Phase = test.phase
-			cmd.follower.OnEvent(pod)
+			if err := cmd.follower.OnEvent(pod); err != nil {
+				t.Error(err.Error())
+			}
 		} else {
 			cmd.follower.OnNoPodEventsYet(nil)
 		}

--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -257,6 +257,7 @@ func (f *Follower) OnNoPodEventsYet(podList *corev1.PodList) {
 	}
 }
 
+// Connect handles the creation of the watch based on the list options provided
 func (f *Follower) Connect(lo metav1.ListOptions) error {
 	return f.pw.Connect(lo)
 }

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -64,16 +64,16 @@ func TestBuildSpecFromFlags(t *testing.T) {
 	spec, dockerfile, builderImage := BuildSpecFromFlags(flags)
 
 	t.Run(".spec.source", func(_ *testing.T) {
-		err := flags.Set(SourceURLFlag, expected.Source.Git.URL)
+		err := flags.Set(SourceGitURLFlag, expected.Source.Git.URL)
 		g.Expect(err).To(o.BeNil())
 
-		err = flags.Set(SourceRevisionFlag, *expected.Source.Git.Revision)
+		err = flags.Set(SourceGitRevisionFlag, *expected.Source.Git.Revision)
 		g.Expect(err).To(o.BeNil())
 
 		err = flags.Set(SourceContextDirFlag, *expected.Source.ContextDir)
 		g.Expect(err).To(o.BeNil())
 
-		err = flags.Set(SourceCredentialsSecretFlag, *expected.Source.Git.CloneSecret)
+		err = flags.Set(SourceGitCloneSecretFlag, *expected.Source.Git.CloneSecret)
 		g.Expect(err).To(o.BeNil())
 
 		err = flags.Set(SourceOCIArtifactPullSecretFlag, *expected.Source.OCIArtifact.PullSecret)

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -20,31 +20,41 @@ const (
 	DockerfileFlag = "dockerfile"
 	// EnvFlag command-line flag.
 	EnvFlag = "env"
+	// SourceGitURLFlag command-line flag.
+	SourceGitURLFlag = "source-git-url"
 	// SourceURLFlag command-line flag.
-	SourceURLFlag = "source-git-url"
+	SourceURLFlag = "source-url"
+	// SourceGitRevisionFlag command-line flag.
+	SourceGitRevisionFlag = "source-git-revision"
 	// SourceRevisionFlag command-line flag.
-	SourceRevisionFlag = "source-git-revision"
+	SourceRevisionFlag = "source-revision"
 	// SourceContextDirFlag command-line flag.
 	SourceContextDirFlag = "source-context-dir"
-	// SourceCredentialsSecretFlag command-line flag.
-	SourceCredentialsSecretFlag = "source-git-clone-secret" // #nosec G101
-	// SourceBundleImageFlag command-line flag
+	// SourceGitCloneSecretFlag command-line flag.
+	SourceGitCloneSecretFlag = "source-git-clone-secret" // #nosec G101
+	// SourceCredentialsSecret command-line flag.
+	SourceCredentialsSecret = "source-credentials-secret" // #nosec G101
+	// SourceOCIArtifactImageFlag command-line flag
 	SourceOCIArtifactImageFlag = "source-oci-artifact-image"
-	// SourceBundlePruneFlag command-line flag
+	// SourceOCIArtifactPruneFlag command-line flag
 	SourceOCIArtifactPruneFlag = "source-oci-artifact-prune"
 	// SourceOCIArtifactPullSecretFlag command-line flag
 	SourceOCIArtifactPullSecretFlag = "source-oci-artifact-pull-secret" // #nosec G101
+	// SourceBundleImageFlag command-line flag
+	SourceBundleImageFlag = "source-bundle-image"
+	// SourceBundlePruneFlag command-line flag
+	SourceBundlePruneFlag = "source-bundle-prune"
 	// StrategyKindFlag command-line flag.
 	StrategyKindFlag = "strategy-kind"
 	// StrategyNameFlag command-line flag.
 	StrategyNameFlag = "strategy-name"
 	// OutputImageFlag command-line flag.
 	OutputImageFlag = "output-image"
-	// OutputInsecure command-line flag.
+	// OutputInsecureFlag command-line flag.
 	OutputInsecureFlag = "output-insecure"
 	// OutputCredentialsSecretFlag command-line flag.
 	OutputCredentialsSecretFlag = "output-credentials-secret" // #nosec G101
-	// ParameterValueFlag command-line flag.
+	// ParamValueFlag command-line flag.
 	ParamValueFlag = "param-value"
 	// ServiceAccountNameFlag command-line flag.
 	ServiceAccountNameFlag = "sa-name"
@@ -74,31 +84,31 @@ const (
 func sourceFlags(flags *pflag.FlagSet, source *buildv1beta1.Source) {
 	flags.StringVar(
 		&source.Git.URL,
-		SourceURLFlag,
+		SourceGitURLFlag,
 		"",
 		"git repository source URL",
 	)
 	flags.StringVar(
 		&source.Git.URL,
-		"source-url",
+		SourceURLFlag,
 		"",
 		"alias for source-git-url",
 	)
-	flags.MarkDeprecated("source-url", fmt.Sprintf("please use --%s instead", SourceURLFlag))
+	_ = flags.MarkDeprecated(SourceURLFlag, fmt.Sprintf("please use --%s instead", SourceGitURLFlag))
 
 	flags.StringVar(
 		source.Git.Revision,
-		SourceRevisionFlag,
+		SourceGitRevisionFlag,
 		"",
 		"git repository source revision",
 	)
 	flags.StringVar(
 		source.Git.Revision,
-		"source-revision",
+		SourceRevisionFlag,
 		"",
 		"alias for source-git-revision",
 	)
-	flags.MarkDeprecated("source-revision", fmt.Sprintf("please use --%s instead", SourceRevisionFlag))
+	_ = flags.MarkDeprecated(SourceRevisionFlag, fmt.Sprintf("please use --%s instead", SourceGitRevisionFlag))
 
 	flags.StringVar(
 		source.ContextDir,
@@ -109,17 +119,17 @@ func sourceFlags(flags *pflag.FlagSet, source *buildv1beta1.Source) {
 
 	flags.StringVar(
 		source.Git.CloneSecret,
-		SourceCredentialsSecretFlag,
+		SourceGitCloneSecretFlag,
 		"",
 		"name of the secret with credentials to access the git source, e.g. git credentials",
 	)
 	flags.StringVar(
 		source.Git.CloneSecret,
-		"source-credentials-secret",
+		SourceCredentialsSecret,
 		"",
 		"name of the secret with credentials to access the source, e.g. credentials",
 	)
-	flags.MarkDeprecated("source-credentials-secret", fmt.Sprintf("please use --%s instead", SourceCredentialsSecretFlag))
+	_ = flags.MarkDeprecated(SourceCredentialsSecret, fmt.Sprintf("please use --%s instead", SourceGitCloneSecretFlag))
 
 	flags.StringVar(
 		&source.OCIArtifact.Image,
@@ -129,11 +139,11 @@ func sourceFlags(flags *pflag.FlagSet, source *buildv1beta1.Source) {
 	)
 	flags.StringVar(
 		&source.OCIArtifact.Image,
-		"source-bundle-image",
+		SourceBundleImageFlag,
 		"",
 		"source bundle image location, e.g. ghcr.io/shipwright-io/sample-go/source-bundle:latest",
 	)
-	flags.MarkDeprecated("source-bundle-image", fmt.Sprintf("please use --%s instead", SourceOCIArtifactImageFlag))
+	_ = flags.MarkDeprecated(SourceBundleImageFlag, fmt.Sprintf("please use --%s instead", SourceOCIArtifactImageFlag))
 
 	flags.StringVar(
 		source.OCIArtifact.PullSecret,
@@ -149,10 +159,10 @@ func sourceFlags(flags *pflag.FlagSet, source *buildv1beta1.Source) {
 	)
 	flags.Var(
 		pruneOptionFlag{ref: source.OCIArtifact.Prune},
-		"source-bundle-prune",
+		SourceBundlePruneFlag,
 		fmt.Sprintf("source bundle prune option, either %s, or %s", buildv1beta1.PruneNever, buildv1beta1.PruneAfterPull),
 	)
-	flags.MarkDeprecated("source-bundle-prune", fmt.Sprintf("please use --%s instead", SourceOCIArtifactPruneFlag))
+	_ = flags.MarkDeprecated(SourceBundlePruneFlag, fmt.Sprintf("please use --%s instead", SourceOCIArtifactPruneFlag))
 }
 
 // strategyFlags flags for ".spec.strategy".
@@ -190,7 +200,7 @@ func imageFlags(flags *pflag.FlagSet, prefix string, image *buildv1beta1.Image) 
 		"",
 		"name of the secret with output image push credentials",
 	)
-	flags.MarkDeprecated(fmt.Sprintf("%s-credentials-secret", prefix), fmt.Sprintf("please use --%s-image-push-secret instead", prefix))
+	_ = flags.MarkDeprecated(fmt.Sprintf("%s-credentials-secret", prefix), fmt.Sprintf("please use --%s-image-push-secret instead", prefix))
 
 	if prefix == "output" {
 		flags.BoolVar(
@@ -210,7 +220,7 @@ func dockerfileFlags(flags *pflag.FlagSet, dockerfile *string) {
 		"",
 		"path to dockerfile relative to repository",
 	)
-	flags.MarkDeprecated("dockerfile", "dockerfile parameter is deprecated")
+	_ = flags.MarkDeprecated("dockerfile", "dockerfile parameter is deprecated")
 }
 
 // builderImageFlag register builder-image flag as an environment variable..
@@ -221,7 +231,7 @@ func builderImageFlag(flags *pflag.FlagSet, builderImage *string) {
 		"",
 		"path to dockerfile relative to repository",
 	)
-	flags.MarkDeprecated("builder-image", "builder-image flag is deprecated, and will be removed in a future release. Use an appropriate parameter for the build strategy instead.")
+	_ = flags.MarkDeprecated(BuilderImageFlag, "builder-image flag is deprecated, and will be removed in a future release. Use an appropriate parameter for the build strategy instead.")
 }
 
 // timeoutFlags register a timeout flag as time.Duration instance.
@@ -259,8 +269,7 @@ func serviceAccountFlags(flags *pflag.FlagSet, sa *string) {
 		false,
 		"generate a Kubernetes service-account for the build",
 	)
-	flags.MarkDeprecated("sa-generate", fmt.Sprintf("this flag has no effect, please use --%s for service account", ServiceAccountNameFlag))
-
+	_ = flags.MarkDeprecated(ServiceAccountGenerateFlag, fmt.Sprintf("this flag has no effect, please use --%s for service account", ServiceAccountNameFlag))
 }
 
 // buildNodeSelectorFlags registers flags for adding BuildSpec.NodeSelector

--- a/pkg/shp/flags/param_value.go
+++ b/pkg/shp/flags/param_value.go
@@ -44,7 +44,7 @@ func (p *ParamArrayValue) Type() string {
 	return "stringArray"
 }
 
-// NewCoreEnvVarArrayValue instantiate a ParamValSliceValue sharing the EnvVar pointer.
+// NewParamArrayValue instantiate a ParamValSliceValue sharing the EnvVar pointer.
 func NewParamArrayValue(params *[]buildv1beta1.ParamValue) *ParamArrayValue {
 	return &ParamArrayValue{params: params}
 }

--- a/pkg/shp/params/params.go
+++ b/pkg/shp/params/params.go
@@ -148,7 +148,7 @@ func (p *Params) Namespace() string {
 	return p.namespace
 }
 
-// NewFollower instantiate a new PodWatcher based on the current instance.
+// NewPodWatcher instantiate a new PodWatcher based on the current instance.
 func (p *Params) NewPodWatcher(ctx context.Context) (*reactor.PodWatcher, error) {
 	if p.pw != nil {
 		return p.pw, nil

--- a/pkg/shp/params/params_test.go
+++ b/pkg/shp/params/params_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/spf13/pflag"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func TestParamsCreation(t *testing.T) {

--- a/pkg/shp/reactor/pod_watcher_test.go
+++ b/pkg/shp/reactor/pod_watcher_test.go
@@ -29,7 +29,8 @@ func Test_PodWatcher_RequestTimeout(t *testing.T) {
 		called = true
 	})
 
-	pw.Start(metav1.ListOptions{})
+	_, err = pw.Start(metav1.ListOptions{})
+	g.Expect(err).ToNot(o.HaveOccurred())
 	g.Expect(called).To(o.BeTrue())
 }
 
@@ -49,7 +50,8 @@ func Test_PodWatcher_ContextTimeout(t *testing.T) {
 		called = true
 	})
 
-	pw.Start(metav1.ListOptions{})
+	_, err = pw.Start(metav1.ListOptions{})
+	g.Expect(err).ToNot(o.HaveOccurred())
 	g.Expect(called).To(o.BeTrue())
 }
 

--- a/pkg/shp/streamer/streamer_test.go
+++ b/pkg/shp/streamer/streamer_test.go
@@ -4,16 +4,16 @@ import (
 	"io"
 	"testing"
 
-	"github.com/onsi/gomega"
-	"github.com/shipwright-io/cli/test/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	o "github.com/onsi/gomega"
+
+	"github.com/shipwright-io/cli/test/mock"
 )
 
 func Test_Streamer(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := o.NewGomegaWithT(t)
 
 	podName := "pod"
 	f := mock.NewFakeClientset(&corev1.Pod{

--- a/pkg/shp/streamer/tar_test.go
+++ b/pkg/shp/streamer/tar_test.go
@@ -6,13 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
-
 	o "github.com/onsi/gomega"
 )
 
 func Test_Tar(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := o.NewGomegaWithT(t)
 
 	tarHelper, err := NewTar("../../..")
 	g.Expect(err).To(o.BeNil())

--- a/pkg/shp/streamer/target.go
+++ b/pkg/shp/streamer/target.go
@@ -7,7 +7,3 @@ type Target struct {
 	Container string // container name
 	BaseDir   string // base directory to store streamed data
 }
-
-func (t *Target) IsEmpty() bool {
-	return t.Pod == "" || t.Namespace == ""
-}

--- a/pkg/shp/tail/tail_test.go
+++ b/pkg/shp/tail/tail_test.go
@@ -44,8 +44,8 @@ func Test_Tail(t *testing.T) {
 	time.Sleep(10 * time.Second)
 	logTail.Stop()
 
-	stdoutWriter.Close()
-	stderrWriter.Close()
+	g.Expect(stdoutWriter.Close()).To(o.Succeed())
+	g.Expect(stderrWriter.Close()).To(o.Succeed())
 
 	// reading out stdout and stderr output by copying the iWriter contents to an intermediary
 	// buffer and checking how many bytes were subject to copying.

--- a/test/mock/fake_clientset.go
+++ b/test/mock/fake_clientset.go
@@ -43,8 +43,8 @@ func (f *FakeClientset) Clientset() *kubernetes.Clientset {
 // roundTripperFn handles the request against the Kubernetes API, and ultimately returns the object
 // requested by the client.
 func (f *FakeClientset) roundTripperFn(req *http.Request) (*http.Response, error) {
-	switch method := req.Method; {
-	case method == "GET":
+	switch req.Method {
+	case "GET":
 		body := io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(f.codec, f.pod))))
 		return &http.Response{
 			StatusCode: http.StatusOK,


### PR DESCRIPTION
# Changes

- Refactor command-line flag variables
- Add comments to exported functions
- Remove unused pointer-receiver function
- Unify Gomega import and usage
- Simplify code as suggested by linter
- Disable package comment linter
- Add error check in unit-test cases

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
