### PR TITLE
Fix: align util package naming with new revive linter expectation

### DIFF
--- a/pkg/shp/cmd/buildrun/logs.go
+++ b/pkg/shp/cmd/buildrun/logs.go
@@ -18,7 +18,7 @@ import (
 	"github.com/shipwright-io/cli/pkg/shp/cmd/follower"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
-	"github.com/shipwright-io/cli/pkg/shp/util"
+	shputil "github.com/shipwright-io/cli/pkg/shp/util"
 )
 
 // LogsCommand contains data input from user for logs sub-command
@@ -111,7 +111,7 @@ func (c *LogsCommand) Run(params *params.Params, ioStreams *genericclioptions.IO
 
 		var b strings.Builder
 		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-			logs, err := util.GetPodLogs(c.cmd.Context(), clientset, pod, container.Name)
+			logs, err := shputil.GetPodLogs(c.cmd.Context(), clientset, pod, container.Name)
 			if err != nil {
 				return err
 			}

--- a/pkg/shp/cmd/follower/follow.go
+++ b/pkg/shp/cmd/follower/follow.go
@@ -13,7 +13,7 @@ import (
 	buildclientset "github.com/shipwright-io/build/pkg/client/clientset/versioned"
 	"github.com/shipwright-io/cli/pkg/shp/reactor"
 	"github.com/shipwright-io/cli/pkg/shp/tail"
-	"github.com/shipwright-io/cli/pkg/shp/util"
+	shputil "github.com/shipwright-io/cli/pkg/shp/util"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -183,7 +183,7 @@ func (f *Follower) OnEvent(pod *corev1.Pod) error {
 			f.Log(fmt.Sprintf("succeeded event for pod %q arrived before or in place of running event so dumping logs now\n", pod.GetName()))
 			var b strings.Builder
 			for _, c := range pod.Spec.Containers {
-				logs, err := util.GetPodLogs(f.ctx, f.clientset, *pod, c.Name)
+				logs, err := shputil.GetPodLogs(f.ctx, f.clientset, *pod, c.Name)
 				if err != nil {
 					f.Log(fmt.Sprintf("could not get logs for container %q: %s\n", c.Name, err.Error()))
 					continue

--- a/pkg/shp/util/doc.go
+++ b/pkg/shp/util/doc.go
@@ -1,2 +1,2 @@
-// Package util contains utility function and constants used in other packages.
-package util
+// Package shputil contains utility function and constants used in other packages.
+package shputil

--- a/pkg/shp/util/logs.go
+++ b/pkg/shp/util/logs.go
@@ -1,4 +1,4 @@
-package util
+package shputil
 
 import (
 	"bytes"


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This PR resolves issue #329 by renaming the generic `util` package to `shputil`, avoiding revive's newly added rule that flags meaningless package names.

This change is in response to the recent update in the revive linter—see its PR [#1312 (detect meaningless package names)](https://github.com/mgechev/revive/pull/1312)—which extended the `var-naming` rule to include checks for generic package names like `util`, `common`, `helpers`, etc.


### Changes
- Renamed package in `pkg/shp/util/*` from `util` to `shputil`
- Updated `doc.go` to reflect the correct package name and follow revive’s `package-comments` rule
- Adjusted import statements to:
  ```go
  import shputil "github.com/shipwright-io/cli/pkg/shp/util"

Fixes #329 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE