### PR TITLE
Fix local source build

### DIFF
--- a/pkg/shp/cmd/build/upload.go
+++ b/pkg/shp/cmd/build/upload.go
@@ -131,11 +131,12 @@ func (u *UploadCommand) Complete(p *params.Params, _ *genericclioptions.IOStream
 	if build.Spec.Source != nil {
 		if build.Spec.Source.OCIArtifact != nil && build.Spec.Source.OCIArtifact.Image != "" {
 			u.sourceBundleImage = build.Spec.Source.OCIArtifact.Image
-
-		} else {
-			u.dataStreamer = streamer.NewStreamer(restConfig, clientset)
 		}
 	}
+
+	// Create a streamer instance to stream data onto pod for local source build.
+	u.dataStreamer = streamer.NewStreamer(restConfig, clientset)
+
 	u.pw, err = p.NewPodWatcher(u.Cmd().Context())
 	return err
 }

--- a/pkg/shp/streamer/streamer.go
+++ b/pkg/shp/streamer/streamer.go
@@ -27,7 +27,7 @@ type Streamer struct {
 type WriterFn func(w io.Writer) error
 
 // tarCmd base tar command to be executed on the POD, a target directory should be appended.
-var tarCmd = []string{"tar", "xfv", "-", "-C"}
+var tarCmd = []string{"tar", "--no-same-permissions", "--no-same-owner", "-xvf", "-", "-C"}
 
 // doneCmd command to notify the container the data streaming is done, thus the container build
 // process can continue.

--- a/pkg/shp/streamer/streamer_test.go
+++ b/pkg/shp/streamer/streamer_test.go
@@ -47,7 +47,7 @@ func Test_Streamer(t *testing.T) {
 		return err
 	}, size)
 	g.Expect(err).To(o.BeNil())
-	g.Expect(re.Command()).To(o.Equal([]string{"tar", "xfv", "-", "-C", "/"}))
+	g.Expect(re.Command()).To(o.Equal([]string{"tar", "--no-same-permissions", "--no-same-owner", "-xvf", "-", "-C", "/"}))
 	g.Expect(re.Stdin()).To(o.Equal(stdin))
 
 	// calling out "done" command on target pod, and making sure the command informed is expected


### PR DESCRIPTION
# Changes
- Data stream was only being initialized when the source is not OCI artifact. Hence, in cases where the source itself is not specified in the Build object, the struct was left uninitialized
- Explicitly set UID and GID to 0 in "tar" header while writing archive, to prevent permission issue with local file having different UID and GID

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #xxx

-->
Fixes #332 
Fixes #338 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixes bugs with builds from local source code
```
