### PR TITLE
Fix buildrun list command

### DIFF
--- a/pkg/shp/cmd/buildrun/list.go
+++ b/pkg/shp/cmd/buildrun/list.go
@@ -106,14 +106,26 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 	for _, br := range brs.Items {
 		name := br.Name
 		buildName := br.Spec.BuildName()
-		outputImage := br.Status.BuildSpec.Output.Image
-		sourceOrigin := br.Status.BuildSpec.Source.Type
+		outputImage := "-"
 		source := "-"
-		if sourceOrigin == "Git" {
-			source = br.Status.BuildSpec.Source.Git.URL
-			revision := br.Status.BuildSpec.Source.Git.Revision
-			if revision != nil {
-				source += "@" + *revision
+		sourceOrigin := "-"
+		// Check if BuildSpec is present in Status as this is an optional pointer field.
+		if br.Status.BuildSpec != nil {
+			outputImage = br.Status.BuildSpec.Output.Image
+
+			// In case the Source is not preset in the BuildSpec, try to get it from BuildRun spec.
+			if br.Status.BuildSpec.Source != nil {
+				sourceOrigin = string(br.Status.BuildSpec.Source.Type)
+			} else if br.Spec.Source != nil {
+				sourceOrigin = string(br.Spec.Source.Type)
+			}
+
+			if sourceOrigin == "Git" {
+				source = br.Status.BuildSpec.Source.Git.URL
+				revision := br.Status.BuildSpec.Source.Git.Revision
+				if revision != nil {
+					source += "@" + *revision
+				}
 			}
 		}
 


### PR DESCRIPTION
# Changes

- Check if BuildSpec exists in Status of BuildRun, since it an optional field in the API
- Try to get SourceOrigin from BuildRunSpec if it doesn't exist in BuildRun status.

Fixes #339 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixes "buildrun list" command for BuildRuns with invalid BuildSpec.
```
