### PR TITLE
[main] fix: Run Shared Setup for Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,8 @@ jobs:
       with:
         ref: ${{ inputs.git-ref }}
         fetch-depth: 0
-
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: 1.23.x
-        cache: true
-        check-latest: true
+    - name: Setup
+      uses: ./.github/actions/setup
 
     - name: Tag release
       run: |


### PR DESCRIPTION
# Changes

Use the shared Setup action to install go and ko.

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.


# Release Notes

```release-note
Fix release action to install common base version of compile tools.
```
