### PR TITLE
ci: add Windows unit test job

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -20,3 +20,16 @@ jobs:
 
       - name: Run Unit Tests
         run: make test-unit
+
+  test-unit-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.x
+          cache: true
+          check-latest: true
+
+      - name: Run Unit Tests
+        run: go test -mod=vendor -race -cover ./cmd/shp/... ./pkg/...


### PR DESCRIPTION
## Summary
- adds a separate `test-unit-windows` GitHub Actions job for Windows unit coverage
- preserves the existing Linux `test-unit` job and status-check name unchanged
- expands the existing `make test-unit` command directly with `go test -mod=vendor -race -cover ./cmd/shp/... ./pkg/...` so the Windows job does not depend on `make`

Fixes #64.

## Testing
- `docker run --rm -v "$PWD":/workspace -w /workspace golang:1.25 go test -mod=vendor -race -cover ./cmd/shp/... ./pkg/...`
- `docker run --rm -v "$PWD":/workspace -w /workspace golang:1.25 sh -c 'GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -mod=vendor ./cmd/shp/...'`
- `git diff --check`

## Notes
The actual Windows unit test execution is intentionally left to upstream GitHub Actions. The existing Linux `test-unit` job remains unchanged so current branch protection/check names are not disturbed; maintainers can decide whether to make the new Windows job required.

This PR was prepared with AI assistance and reviewed before submission.

```release-note
NONE
```