### PR TITLE
Fix e2e failures by declaring the e2e registry as insecure for buildpacks builds

### DIFF
--- a/test/e2e/buildrun-gather.bats
+++ b/test/e2e/buildrun-gather.bats
@@ -22,7 +22,8 @@ teardown() {
   run shp build create ${build_name} \
     --source-git-url=https://github.com/shipwright-io/sample-go \
     --source-context-dir=source-build \
-    --output-image=${output_image}
+    --output-image=${output_image} \
+    --output-insecure=true
   assert_success
 
   run shp buildrun create ${buildrun_name} --buildref-name=${build_name}

--- a/test/e2e/log-follow--follow.bats
+++ b/test/e2e/log-follow--follow.bats
@@ -23,7 +23,8 @@ teardown() {
     run shp build create ${build_name} \
         --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
-        --output-image=${output_image}
+        --output-image=${output_image} \
+        --output-insecure=true
     assert_success
 
     # initiate a BuildRun

--- a/test/e2e/log-follow-F.bats
+++ b/test/e2e/log-follow-F.bats
@@ -23,7 +23,8 @@ teardown() {
     run shp build create ${build_name} \
         --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
-        --output-image=${output_image}
+        --output-image=${output_image} \
+        --output-insecure=true
     assert_success
 
     # initiate a BuildRun

--- a/test/e2e/run-follow.bats
+++ b/test/e2e/run-follow.bats
@@ -23,7 +23,8 @@ teardown() {
     run shp build create ${build_name} \
         --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
-        --output-image=${output_image}
+        --output-image=${output_image} \
+        --output-insecure=true
     assert_success
 
     # initiate a BuildRun with -F

--- a/test/e2e/upload.bats
+++ b/test/e2e/upload.bats
@@ -41,7 +41,8 @@ function assert_shp_upload_follow_output() {
 	run shp build create ${build_name} \
 		--source-git-url="${source_url}" \
 		--source-context-dir="source-build" \
-		--output-image="${output_image}"
+		--output-image="${output_image}" \
+		--output-insecure=true
 	assert_success
 
 	# cloning the same repository used for the build in the test temporary directory, this is the


### PR DESCRIPTION
# Changes

The e2e tests push to the in-cluster registry (`registry.registry.svc.cluster.local:32222`) over plain HTTP. Since 2026-08-22 the `buildpacks-v3` sample strategy's `paketobuildpacks/builder-jammy-full:latest` image ships CNB lifecycle 0.21.17, which no longer falls back to HTTP for non-localhost registries unless they are listed in `CNB_INSECURE_REGISTRIES`. The strategy only sets that when the Build declares its output as insecure, so every buildpacks build in e2e now fails with:

```
failed to initialize analyzer: validating registry read access: ... http: server gave HTTP response to HTTPS client
```

This adds `--output-insecure=true` to the `shp build create` calls in the tests that build against that registry (`buildrun-gather`, `log-follow-F`, `log-follow--follow`, `run-follow`, `upload`), matching what `upload with bundle` already does.

Verified on a local kind cluster: the 5 tests that fail in CI (`gather`, `logs follow` x2, `build run follow`, `build upload`) all pass with this change.

Related upstream: shipwright-io/build#2301 (pin the builder image) / shipwright-io/build#2302.

This PR was assisted by Claude.

# Type of PR

/kind cleanup

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
