### PR TITLE
fix(streamer): prevent skipPath from over-matching .git prefix

### DIFF
--- a/pkg/shp/streamer/tar.go
+++ b/pkg/shp/streamer/tar.go
@@ -24,14 +24,14 @@ func (t *Tar) skipPath(fpath string, stat fs.FileInfo) bool {
 	if !stat.Mode().IsRegular() {
 		return true
 	}
-	cleanFpath := filepath.ToSlash(fpath)
-	cleanSrc := filepath.ToSlash(filepath.Clean(t.src))
-	gitDir := path.Join(cleanSrc, ".git")
-
-	if cleanFpath == gitDir || strings.HasPrefix(cleanFpath, gitDir+"/") {
-		return true
+	relPath, err := filepath.Rel(t.src, fpath)
+	if err == nil {
+		cleanPath := filepath.ToSlash(relPath)
+		if cleanPath == ".git" || strings.HasPrefix(cleanPath, ".git/") {
+			return true
+		}
 	}
-	
+
 	if t.gitIgnore != nil {
 		return t.gitIgnore.MatchesPath(fpath)
 	}

--- a/pkg/shp/streamer/tar.go
+++ b/pkg/shp/streamer/tar.go
@@ -24,13 +24,18 @@ func (t *Tar) skipPath(fpath string, stat fs.FileInfo) bool {
 	if !stat.Mode().IsRegular() {
 		return true
 	}
-	if strings.HasPrefix(fpath, path.Join(t.src, ".git")) {
+	cleanFpath := filepath.ToSlash(fpath)
+	cleanSrc := filepath.ToSlash(filepath.Clean(t.src))
+	gitDir := path.Join(cleanSrc, ".git")
+
+	if cleanFpath == gitDir || strings.HasPrefix(cleanFpath, gitDir+"/") {
 		return true
 	}
-	if t.gitIgnore == nil {
-		return false
+	
+	if t.gitIgnore != nil {
+		return t.gitIgnore.MatchesPath(fpath)
 	}
-	return t.gitIgnore.MatchesPath(fpath)
+	return false
 }
 
 // Create the actual tar by inspecting all files in source path, skipping some.

--- a/pkg/shp/streamer/tar.go
+++ b/pkg/shp/streamer/tar.go
@@ -26,8 +26,8 @@ func (t *Tar) skipPath(fpath string, stat fs.FileInfo) bool {
 	}
 	relPath, err := filepath.Rel(t.src, fpath)
 	if err == nil {
-		cleanPath := filepath.ToSlash(relPath)
-		if cleanPath == ".git" || strings.HasPrefix(cleanPath, ".git/") {
+		cleanPath := "/" + filepath.ToSlash(relPath) + "/"
+		if strings.Contains(cleanPath, "/.git/") {
 			return true
 		}
 	}

--- a/pkg/shp/streamer/tar_test.go
+++ b/pkg/shp/streamer/tar_test.go
@@ -3,6 +3,7 @@ package streamer
 import (
 	"archive/tar"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,6 +27,7 @@ func Test_Tar(t *testing.T) {
 
 	tarReader := tar.NewReader(reader)
 	counter := 0
+	foundGitIgnore := false
 	for {
 		header, err := tarReader.Next()
 		if err != nil {
@@ -37,10 +39,22 @@ func Test_Tar(t *testing.T) {
 		counter++
 		name := header.Name
 
+		cleanName := filepath.ToSlash(name)
+		// On windows, trimPrefix might fail to trim the prefix cleanly due to slash mismatch, leaving ../../../ prefix.
+		if cleanName == ".gitignore" || strings.HasSuffix(cleanName, "/.gitignore") {
+			// Ensure it's not a vendor or nested gitignore
+			if !strings.Contains(cleanName, "vendor/") {
+				foundGitIgnore = true
+			}
+		}
+
 		// making sure that undesired entries are not present on the list of files caputured by the
 		// tar helper
-		g.Expect(strings.HasPrefix(name, ".git/")).To(o.BeFalse())
-		g.Expect(strings.HasPrefix(name, "_output/")).To(o.BeFalse())
+		if strings.Contains(cleanName, ".git/") && !strings.Contains(cleanName, ".gitignore") {
+			g.Expect(strings.Contains(cleanName, ".git/")).To(o.BeFalse(), "should not contain .git/")
+		}
+		g.Expect(strings.HasPrefix(cleanName, "_output/")).To(o.BeFalse())
 	}
+	g.Expect(foundGitIgnore).To(o.BeTrue(), "expected .gitignore to be included in the tarball")
 	g.Expect(counter > 10).To(o.BeTrue())
 }

--- a/pkg/shp/streamer/tar_test.go
+++ b/pkg/shp/streamer/tar_test.go
@@ -40,12 +40,8 @@ func Test_Tar(t *testing.T) {
 		name := header.Name
 
 		cleanName := filepath.ToSlash(name)
-		// On windows, trimPrefix might fail to trim the prefix cleanly due to slash mismatch, leaving ../../../ prefix.
-		if cleanName == ".gitignore" || strings.HasSuffix(cleanName, "/.gitignore") {
-			// Ensure it's not a vendor or nested gitignore
-			if !strings.Contains(cleanName, "vendor/") {
-				foundGitIgnore = true
-			}
+		if cleanName == ".gitignore" {
+			foundGitIgnore = true
 		}
 
 		// making sure that undesired entries are not present on the list of files caputured by the

--- a/pkg/shp/streamer/tar_test.go
+++ b/pkg/shp/streamer/tar_test.go
@@ -50,9 +50,7 @@ func Test_Tar(t *testing.T) {
 
 		// making sure that undesired entries are not present on the list of files caputured by the
 		// tar helper
-		if strings.Contains(cleanName, ".git/") && !strings.Contains(cleanName, ".gitignore") {
-			g.Expect(strings.Contains(cleanName, ".git/")).To(o.BeFalse(), "should not contain .git/")
-		}
+		g.Expect(strings.Split(cleanName, "/")).NotTo(o.ContainElement(".git"), "should not contain a .git path component")
 		g.Expect(strings.HasPrefix(cleanName, "_output/")).To(o.BeFalse())
 	}
 	g.Expect(foundGitIgnore).To(o.BeTrue(), "expected .gitignore to be included in the tarball")

--- a/pkg/shp/streamer/util.go
+++ b/pkg/shp/streamer/util.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 type writeCounter struct{ total int }
@@ -17,17 +16,17 @@ func (wc *writeCounter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func trimPrefix(prefix, fpath string) string {
-	return strings.TrimPrefix(strings.ReplaceAll(fpath, prefix, ""), string(filepath.Separator))
-}
-
 func writeFileToTar(tw *tar.Writer, src, fpath string, stat fs.FileInfo) error {
 	header, err := tar.FileInfoHeader(stat, stat.Name())
 	if err != nil {
 		return err
 	}
 
-	header.Name = trimPrefix(src, fpath)
+	relPath, err := filepath.Rel(src, fpath)
+	if err != nil {
+		return err
+	}
+	header.Name = filepath.ToSlash(relPath)
 	if err := tw.WriteHeader(header); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This fixes a bug where `skipPath` in the streamer would unintentionally drop files that shared the `.git` prefix, such as `.gitignore`, `.gitmodules`, and `.gitattributes`. The matcher now checks the source-relative path and only excludes a path component named `.git`.

The relative-path comparison also preserves Windows UNC paths correctly.

Additionally, it normalizes cross-platform paths using `filepath.ToSlash` prior to string matching to safeguard against path comparison bugs when the CLI is run on Windows machines.

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Fixes #408 
# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind bug

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Fixed a bug in the `shp` CLI local source streamer where files prefixed with `.git` (such as `.gitignore`, `.gitmodules`, and `.gitattributes`) were incorrectly omitted from the build context.
```
